### PR TITLE
Add environment-aware config validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 # Copy this file to .env and customize as needed
 
 # =============================================================================
+# Environment
+# =============================================================================
+# Environment: development, staging, production, test
+# Production/staging modes enforce stricter validation at startup
+ENVIRONMENT=development
+
+# =============================================================================
 # Database Configuration
 # =============================================================================
 DB_ROOT_PASSWORD=rootpassword

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,19 +35,13 @@ func main() {
 		cfg.Sentry.Release = version
 	}
 
-	// Validate required configuration
-	if cfg.JWT.Secret == "" {
-		log.Fatal("JWT_SECRET environment variable is required")
+	// Validate configuration for the current environment
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("Configuration error:\n  - %v", err)
 	}
-	// MFA encryption key is only required if MFA is enabled
-	if cfg.MFA.Required {
-		if cfg.MFA.EncryptionKey == "" {
-			log.Fatal("MFA_ENCRYPTION_KEY environment variable is required (32 characters)")
-		}
-		if len(cfg.MFA.EncryptionKey) != 32 {
-			log.Fatalf("MFA_ENCRYPTION_KEY must be exactly 32 characters (got %d)", len(cfg.MFA.EncryptionKey))
-		}
-	} else {
+	log.Printf("Environment: %s", cfg.Env)
+
+	if !cfg.MFA.Required {
 		log.Println("WARNING: MFA is disabled (MFA_REQUIRED=false). This should only be used in development.")
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       db:
         condition: service_healthy
     environment:
+      - ENVIRONMENT=development
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8080
       - DB_HOST=db
@@ -133,6 +134,7 @@ services:
       db-test:
         condition: service_healthy
     environment:
+      - ENVIRONMENT=test
       - TEST_DB_HOST=db-test
       - TEST_DB_PORT=3306
       - TEST_DB_USER=root
@@ -203,6 +205,7 @@ services:
       db-test:
         condition: service_healthy
     environment:
+      - ENVIRONMENT=test
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8080
       - DB_HOST=db-test

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,37 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// Environment represents the application runtime environment
+type Environment string
+
+const (
+	EnvDevelopment Environment = "development"
+	EnvStaging     Environment = "staging"
+	EnvProduction  Environment = "production"
+	EnvTest        Environment = "test"
+)
+
+// IsProduction returns true for environments that require strict validation
+func (e Environment) IsProduction() bool {
+	return e == EnvProduction || e == EnvStaging
+}
+
+// IsValid returns whether the environment is a recognized value
+func (e Environment) IsValid() bool {
+	switch e {
+	case EnvDevelopment, EnvStaging, EnvProduction, EnvTest:
+		return true
+	default:
+		return false
+	}
+}
 
 // MailProvider represents the mailing service provider type
 type MailProvider string
@@ -17,6 +43,7 @@ const (
 
 // Config holds all application configuration
 type Config struct {
+	Env          Environment
 	Server       ServerConfig
 	Database     DatabaseConfig
 	JWT          JWTConfig
@@ -208,6 +235,7 @@ type EmailConfig struct {
 // Load reads configuration from environment variables
 func Load() *Config {
 	return &Config{
+		Env: Environment(getEnv("ENVIRONMENT", "development")),
 		Server: ServerConfig{
 			Host:          getEnv("SERVER_HOST", "0.0.0.0"),
 			Port:          getEnvInt("SERVER_PORT", 8080),
@@ -346,6 +374,95 @@ func (p MailProvider) IsValid() bool {
 // String returns the string representation of the mail provider
 func (p MailProvider) String() string {
 	return string(p)
+}
+
+// Validate checks that the configuration is valid for the current environment.
+// It collects all errors and returns them joined so operators see every issue at once.
+func (c *Config) Validate() error {
+	var errs []string
+
+	// Environment must be recognized
+	if !c.Env.IsValid() {
+		errs = append(errs, fmt.Sprintf("ENVIRONMENT %q is not valid (must be development, staging, production, or test)", string(c.Env)))
+	}
+
+	// Always required: JWT secret
+	if c.JWT.Secret == "" {
+		errs = append(errs, "JWT_SECRET is required")
+	} else if len(c.JWT.Secret) < 32 {
+		errs = append(errs, fmt.Sprintf("JWT_SECRET must be at least 32 characters (got %d)", len(c.JWT.Secret)))
+	}
+
+	// MFA encryption key required when MFA is enabled
+	if c.MFA.Required {
+		if c.MFA.EncryptionKey == "" {
+			errs = append(errs, "MFA_ENCRYPTION_KEY is required when MFA_REQUIRED=true")
+		} else if len(c.MFA.EncryptionKey) != 32 {
+			errs = append(errs, fmt.Sprintf("MFA_ENCRYPTION_KEY must be exactly 32 characters (got %d)", len(c.MFA.EncryptionKey)))
+		}
+	}
+
+	// Email backend must be valid
+	if !c.Email.Backend.IsValid() {
+		errs = append(errs, fmt.Sprintf("EMAIL_BACKEND %q is not valid (must be mock, sendgrid, or smtp)", string(c.Email.Backend)))
+	}
+
+	// Mail provider must be valid
+	if !c.MailProvider.IsValid() {
+		errs = append(errs, fmt.Sprintf("MAIL_PROVIDER %q is not valid (must be lob or postgrid)", string(c.MailProvider)))
+	}
+
+	// Production/staging-only checks
+	if c.Env.IsProduction() {
+		if !c.Server.SecureCookies {
+			errs = append(errs, "SECURE_COOKIES must be true in production/staging")
+		}
+		if c.Email.Backend == EmailBackendMock {
+			errs = append(errs, "EMAIL_BACKEND cannot be \"mock\" in production/staging")
+		}
+		if !c.Email.Enabled {
+			errs = append(errs, "EMAIL_ENABLED must be true in production/staging")
+		}
+		if c.Database.Password == "" {
+			errs = append(errs, "DB_PASSWORD cannot be empty in production/staging")
+		}
+		if c.Mapbox.SecretToken == "" {
+			errs = append(errs, "MAPBOX_SECRET_TOKEN is required in production/staging")
+		}
+
+		// Mail provider API key
+		switch c.MailProvider {
+		case MailProviderLob:
+			if c.Lob.APIKey == "" {
+				errs = append(errs, "LOB_API_KEY is required in production/staging")
+			}
+		case MailProviderPostgrid:
+			if c.Postgrid.PrintMailAPIKey == "" {
+				errs = append(errs, "POSTGRID_PRINT_API_KEY is required in production/staging")
+			}
+		}
+
+		// Email backend credentials
+		if c.Email.Backend == EmailBackendSendGrid && c.Email.SendGridAPIKey == "" {
+			errs = append(errs, "SENDGRID_API_KEY is required when EMAIL_BACKEND=sendgrid")
+		}
+		if c.Email.Backend == EmailBackendSMTP {
+			if c.Email.SMTPHost == "" {
+				errs = append(errs, "SMTP_HOST is required when EMAIL_BACKEND=smtp")
+			}
+			if c.Email.SMTPUser == "" {
+				errs = append(errs, "SMTP_USER is required when EMAIL_BACKEND=smtp")
+			}
+			if c.Email.SMTPPassword == "" {
+				errs = append(errs, "SMTP_PASSWORD is required when EMAIL_BACKEND=smtp")
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n  - "))
+	}
+	return nil
 }
 
 func getEnv(key, defaultValue string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -168,6 +169,347 @@ func TestSplitCSV(t *testing.T) {
 			}
 		})
 	}
+}
+
+// validDevConfig returns a minimal Config that passes validation in development mode.
+func validDevConfig() *Config {
+	return &Config{
+		Env: EnvDevelopment,
+		JWT: JWTConfig{
+			Secret: "development_secret_key_at_least_32_characters_long",
+		},
+		MFA: MFAConfig{
+			Required: false,
+		},
+		Email: EmailConfig{
+			Backend: EmailBackendMock,
+		},
+		MailProvider: MailProviderLob,
+	}
+}
+
+// validProdConfig returns a Config that passes validation in production mode.
+func validProdConfig() *Config {
+	return &Config{
+		Env: EnvProduction,
+		Server: ServerConfig{
+			SecureCookies: true,
+		},
+		Database: DatabaseConfig{
+			Password: "strong-db-password",
+		},
+		JWT: JWTConfig{
+			Secret: "production_secret_key_at_least_32_characters_long",
+		},
+		MFA: MFAConfig{
+			Required:      true,
+			EncryptionKey: "01234567890123456789012345678901",
+		},
+		Mapbox: MapboxConfig{
+			SecretToken: "sk.mapbox-secret-token",
+		},
+		MailProvider: MailProviderLob,
+		Lob: LobConfig{
+			APIKey: "lob-api-key",
+		},
+		Email: EmailConfig{
+			Backend:        EmailBackendSendGrid,
+			Enabled:        true,
+			SendGridAPIKey: "sg-api-key",
+		},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("valid dev config passes", func(t *testing.T) {
+		cfg := validDevConfig()
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("valid production config passes", func(t *testing.T) {
+		cfg := validProdConfig()
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid ENVIRONMENT fails", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.Env = "bogus"
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid ENVIRONMENT")
+		}
+		if !strings.Contains(err.Error(), "ENVIRONMENT") {
+			t.Errorf("expected error to mention ENVIRONMENT, got: %v", err)
+		}
+	})
+
+	t.Run("empty JWT_SECRET fails", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.JWT.Secret = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for empty JWT_SECRET")
+		}
+		if !strings.Contains(err.Error(), "JWT_SECRET is required") {
+			t.Errorf("expected error to mention JWT_SECRET, got: %v", err)
+		}
+	})
+
+	t.Run("short JWT_SECRET fails", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.JWT.Secret = "too-short"
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for short JWT_SECRET")
+		}
+		if !strings.Contains(err.Error(), "at least 32 characters") {
+			t.Errorf("expected error about min length, got: %v", err)
+		}
+	})
+
+	t.Run("MFA_ENCRYPTION_KEY required when MFA enabled", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.MFA.Required = true
+		cfg.MFA.EncryptionKey = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for missing MFA_ENCRYPTION_KEY")
+		}
+		if !strings.Contains(err.Error(), "MFA_ENCRYPTION_KEY is required") {
+			t.Errorf("expected error about MFA_ENCRYPTION_KEY, got: %v", err)
+		}
+	})
+
+	t.Run("MFA_ENCRYPTION_KEY wrong length fails", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.MFA.Required = true
+		cfg.MFA.EncryptionKey = "too-short"
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for wrong-length MFA_ENCRYPTION_KEY")
+		}
+		if !strings.Contains(err.Error(), "exactly 32 characters") {
+			t.Errorf("expected error about 32 characters, got: %v", err)
+		}
+	})
+
+	t.Run("invalid email backend fails", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.Email.Backend = "carrier_pigeon"
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid EMAIL_BACKEND")
+		}
+		if !strings.Contains(err.Error(), "EMAIL_BACKEND") {
+			t.Errorf("expected error about EMAIL_BACKEND, got: %v", err)
+		}
+	})
+
+	t.Run("invalid mail provider fails", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.MailProvider = "usps"
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid MAIL_PROVIDER")
+		}
+		if !strings.Contains(err.Error(), "MAIL_PROVIDER") {
+			t.Errorf("expected error about MAIL_PROVIDER, got: %v", err)
+		}
+	})
+
+	t.Run("production with SECURE_COOKIES=false fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Server.SecureCookies = false
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for SECURE_COOKIES=false in production")
+		}
+		if !strings.Contains(err.Error(), "SECURE_COOKIES") {
+			t.Errorf("expected error about SECURE_COOKIES, got: %v", err)
+		}
+	})
+
+	t.Run("production with mock email backend fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Email.Backend = EmailBackendMock
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for mock email in production")
+		}
+		if !strings.Contains(err.Error(), "EMAIL_BACKEND") {
+			t.Errorf("expected error about EMAIL_BACKEND, got: %v", err)
+		}
+	})
+
+	t.Run("production with EMAIL_ENABLED=false fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Email.Enabled = false
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for EMAIL_ENABLED=false in production")
+		}
+		if !strings.Contains(err.Error(), "EMAIL_ENABLED") {
+			t.Errorf("expected error about EMAIL_ENABLED, got: %v", err)
+		}
+	})
+
+	t.Run("production with empty DB password fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Database.Password = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for empty DB_PASSWORD in production")
+		}
+		if !strings.Contains(err.Error(), "DB_PASSWORD") {
+			t.Errorf("expected error about DB_PASSWORD, got: %v", err)
+		}
+	})
+
+	t.Run("production with empty MAPBOX_SECRET_TOKEN fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Mapbox.SecretToken = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for empty MAPBOX_SECRET_TOKEN in production")
+		}
+		if !strings.Contains(err.Error(), "MAPBOX_SECRET_TOKEN") {
+			t.Errorf("expected error about MAPBOX_SECRET_TOKEN, got: %v", err)
+		}
+	})
+
+	t.Run("production with lob and empty LOB_API_KEY fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Lob.APIKey = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for empty LOB_API_KEY in production")
+		}
+		if !strings.Contains(err.Error(), "LOB_API_KEY") {
+			t.Errorf("expected error about LOB_API_KEY, got: %v", err)
+		}
+	})
+
+	t.Run("production with postgrid and empty POSTGRID_PRINT_API_KEY fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.MailProvider = MailProviderPostgrid
+		cfg.Postgrid.PrintMailAPIKey = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for empty POSTGRID_PRINT_API_KEY in production")
+		}
+		if !strings.Contains(err.Error(), "POSTGRID_PRINT_API_KEY") {
+			t.Errorf("expected error about POSTGRID_PRINT_API_KEY, got: %v", err)
+		}
+	})
+
+	t.Run("production with sendgrid and empty SENDGRID_API_KEY fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Email.SendGridAPIKey = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for empty SENDGRID_API_KEY in production")
+		}
+		if !strings.Contains(err.Error(), "SENDGRID_API_KEY") {
+			t.Errorf("expected error about SENDGRID_API_KEY, got: %v", err)
+		}
+	})
+
+	t.Run("production with smtp and missing credentials fails", func(t *testing.T) {
+		cfg := validProdConfig()
+		cfg.Email.Backend = EmailBackendSMTP
+		cfg.Email.SMTPHost = ""
+		cfg.Email.SMTPUser = ""
+		cfg.Email.SMTPPassword = ""
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for missing SMTP credentials in production")
+		}
+		if !strings.Contains(err.Error(), "SMTP_HOST") {
+			t.Errorf("expected error about SMTP_HOST, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "SMTP_USER") {
+			t.Errorf("expected error about SMTP_USER, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "SMTP_PASSWORD") {
+			t.Errorf("expected error about SMTP_PASSWORD, got: %v", err)
+		}
+	})
+
+	t.Run("staging treated as production", func(t *testing.T) {
+		cfg := validDevConfig()
+		cfg.Env = EnvStaging
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for staging env with dev defaults")
+		}
+		if !strings.Contains(err.Error(), "SECURE_COOKIES") {
+			t.Errorf("expected staging to enforce SECURE_COOKIES, got: %v", err)
+		}
+	})
+
+	t.Run("collects multiple errors at once", func(t *testing.T) {
+		cfg := &Config{
+			Env:          EnvProduction,
+			JWT:          JWTConfig{Secret: ""},
+			Email:        EmailConfig{Backend: EmailBackendMock},
+			MailProvider: MailProviderLob,
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected multiple errors")
+		}
+		errorText := err.Error()
+		// Should contain at least JWT_SECRET, SECURE_COOKIES, EMAIL_BACKEND, DB_PASSWORD
+		for _, keyword := range []string{"JWT_SECRET", "SECURE_COOKIES", "EMAIL_BACKEND", "DB_PASSWORD"} {
+			if !strings.Contains(errorText, keyword) {
+				t.Errorf("expected error to mention %s, got: %v", keyword, err)
+			}
+		}
+	})
+}
+
+func TestEnvironment_IsProduction(t *testing.T) {
+	tests := []struct {
+		env      Environment
+		expected bool
+	}{
+		{EnvProduction, true},
+		{EnvStaging, true},
+		{EnvDevelopment, false},
+		{EnvTest, false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.env), func(t *testing.T) {
+			if got := tt.env.IsProduction(); got != tt.expected {
+				t.Errorf("Environment(%q).IsProduction() = %v, want %v", tt.env, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoad_Environment(t *testing.T) {
+	orig := os.Getenv("ENVIRONMENT")
+	defer func() { _ = os.Setenv("ENVIRONMENT", orig) }()
+
+	t.Run("defaults to development", func(t *testing.T) {
+		_ = os.Unsetenv("ENVIRONMENT")
+		cfg := Load()
+		if cfg.Env != EnvDevelopment {
+			t.Errorf("expected default env %q, got %q", EnvDevelopment, cfg.Env)
+		}
+	})
+
+	t.Run("loads from ENVIRONMENT", func(t *testing.T) {
+		_ = os.Setenv("ENVIRONMENT", "production")
+		cfg := Load()
+		if cfg.Env != EnvProduction {
+			t.Errorf("expected env %q, got %q", EnvProduction, cfg.Env)
+		}
+	})
 }
 
 func TestConsensusConfig_RequiredVotes(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `Environment` type (`development`, `staging`, `production`, `test`) loaded from the existing `ENVIRONMENT` env var (defaults to `development`)
- Add `Validate()` method on `*Config` that replaces ad-hoc JWT/MFA checks in `main.go`
- Dev/test mode keeps current permissive defaults; production/staging mode fails fast on missing or insecure configuration (secure cookies, real email backend, DB password, API keys, SMTP/SendGrid credentials)
- All validation errors are collected and reported at once so operators can fix everything in one pass

## Test plan
- [x] `go test ./internal/config/` — 20 new test cases for `Validate()`, `IsProduction()`, and `Load()` environment loading
- [x] `go build ./cmd/server/` — compiles cleanly
- [ ] `just dev-full` — app starts normally (ENVIRONMENT defaults to development)
- [ ] `ENVIRONMENT=production just run` — fails fast with clear error listing