### PR TITLE
Add per-endpoint auth rate limiting and account lockout

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -210,6 +210,8 @@ func main() {
 		baseURL,
 		encryptionKeyRepo,
 	)
+	authHandler.SetRateLimiter(rateLimiter)
+
 	mfaHandler := handlers.NewMFAHandler(db, userRepo, mfaService, jwtAuth, cfg.Server.SecureCookies, auditRepo)
 	regionHandler := handlers.NewRegionHandler(regionRepo, mapboxService, auditRepo)
 	signalGroupHandler := handlers.NewSignalGroupHandler(db, signalGroupRepo, encryptedSecretRepo, regionRepo, auditRepo)

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -89,7 +89,8 @@ func (r *UserRepository) GetByID(ctx context.Context, id string) (*models.User, 
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users WHERE id = ?
 	`
 
@@ -117,6 +118,8 @@ func (r *UserRepository) GetByID(ctx context.Context, id string) (*models.User, 
 		&user.CreatedAt,
 		&user.LastLogin,
 		&user.DeletedAt,
+		&user.FailedLoginAttempts,
+		&user.LockedUntil,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -137,7 +140,8 @@ func (r *UserRepository) GetByEmail(ctx context.Context, email string) (*models.
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users WHERE email = ?
 	`
 
@@ -165,6 +169,8 @@ func (r *UserRepository) GetByEmail(ctx context.Context, email string) (*models.
 		&user.CreatedAt,
 		&user.LastLogin,
 		&user.DeletedAt,
+		&user.FailedLoginAttempts,
+		&user.LockedUntil,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -185,7 +191,8 @@ func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*m
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users WHERE username = ?
 	`
 
@@ -213,6 +220,8 @@ func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*m
 		&user.CreatedAt,
 		&user.LastLogin,
 		&user.DeletedAt,
+		&user.FailedLoginAttempts,
+		&user.LockedUntil,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -234,7 +243,8 @@ func (r *UserRepository) GetByEmailOrUsername(ctx context.Context, identifier st
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users WHERE email = ? OR username = ?
 	`
 
@@ -262,6 +272,8 @@ func (r *UserRepository) GetByEmailOrUsername(ctx context.Context, identifier st
 		&user.CreatedAt,
 		&user.LastLogin,
 		&user.DeletedAt,
+		&user.FailedLoginAttempts,
+		&user.LockedUntil,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -324,7 +336,8 @@ func (r *UserRepository) Search(ctx context.Context, query string, page, limit i
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users
 		WHERE (? = '' OR email LIKE ? OR username LIKE ?)
 		ORDER BY created_at DESC
@@ -363,6 +376,8 @@ func (r *UserRepository) Search(ctx context.Context, query string, page, limit i
 			&user.CreatedAt,
 			&user.LastLogin,
 			&user.DeletedAt,
+			&user.FailedLoginAttempts,
+			&user.LockedUntil,
 		); err != nil {
 			return nil, 0, err
 		}
@@ -521,7 +536,8 @@ func (r *UserRepository) GetByNormalizedEmail(ctx context.Context, normalizedEma
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users WHERE email_normalized = ?
 	`
 
@@ -549,6 +565,8 @@ func (r *UserRepository) GetByNormalizedEmail(ctx context.Context, normalizedEma
 		&user.CreatedAt,
 		&user.LastLogin,
 		&user.DeletedAt,
+		&user.FailedLoginAttempts,
+		&user.LockedUntil,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -632,7 +650,8 @@ func (r *UserRepository) GetByIDForUpdate(ctx context.Context, tx *sql.Tx, id st
 		       mfa_secret, mfa_enabled, mfa_backup_codes, mfa_setup_required,
 		       email_verified, email_normalized,
 		       is_blocked, blocked_at, blocked_by, block_reason,
-		       address_hash, created_at, last_login, deleted_at
+		       address_hash, created_at, last_login, deleted_at,
+		       failed_login_attempts, locked_until
 		FROM users WHERE id = ?
 		FOR UPDATE
 	`
@@ -661,6 +680,8 @@ func (r *UserRepository) GetByIDForUpdate(ctx context.Context, tx *sql.Tx, id st
 		&user.CreatedAt,
 		&user.LastLogin,
 		&user.DeletedAt,
+		&user.FailedLoginAttempts,
+		&user.LockedUntil,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -825,6 +846,36 @@ func (r *UserRepository) GetSoleVerifiedSchools(ctx context.Context, userID stri
 		schools = append(schools, school)
 	}
 	return schools, rows.Err()
+}
+
+// IncrementFailedLoginAttempts atomically increments the failed login counter and returns the new count
+func (r *UserRepository) IncrementFailedLoginAttempts(ctx context.Context, userID string) (int, error) {
+	query := `UPDATE users SET failed_login_attempts = failed_login_attempts + 1 WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, userID)
+	if err != nil {
+		return 0, err
+	}
+
+	var count int
+	err = r.db.QueryRowContext(ctx, `SELECT failed_login_attempts FROM users WHERE id = ?`, userID).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// LockAccount sets the locked_until timestamp for an account
+func (r *UserRepository) LockAccount(ctx context.Context, userID string, lockedUntil time.Time) error {
+	query := `UPDATE users SET locked_until = ? WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, lockedUntil.UTC(), userID)
+	return err
+}
+
+// ResetFailedLoginAttempts clears the failed login counter and lock
+func (r *UserRepository) ResetFailedLoginAttempts(ctx context.Context, userID string) error {
+	query := `UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, userID)
+	return err
 }
 
 // GetVerifiedUsersInRegion returns users who are postcard OR vouch verified in a specific region.

--- a/internal/database/users_lockout_test.go
+++ b/internal/database/users_lockout_test.go
@@ -1,0 +1,412 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/opencrr/communityrapidresponse.net/internal/models"
+)
+
+func TestUserRepository_IncrementFailedLoginAttempts(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	// Cleanup before test
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_incr@example.com'")
+
+	user := &models.User{
+		Username:     "lockout_incr",
+		Email:        "lockout_incr@example.com",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	t.Run("increments from zero", func(t *testing.T) {
+		count, err := repo.IncrementFailedLoginAttempts(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to increment: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Expected count 1, got %d", count)
+		}
+	})
+
+	t.Run("increments again", func(t *testing.T) {
+		count, err := repo.IncrementFailedLoginAttempts(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to increment: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("Expected count 2, got %d", count)
+		}
+	})
+
+	t.Run("user reflects new count via GetByID", func(t *testing.T) {
+		retrieved, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if retrieved.FailedLoginAttempts != 2 {
+			t.Errorf("Expected FailedLoginAttempts=2, got %d", retrieved.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("count visible via GetByEmail", func(t *testing.T) {
+		retrieved, err := repo.GetByEmail(ctx, "lockout_incr@example.com")
+		if err != nil {
+			t.Fatalf("Failed to get user by email: %v", err)
+		}
+		if retrieved.FailedLoginAttempts != 2 {
+			t.Errorf("Expected FailedLoginAttempts=2 via GetByEmail, got %d", retrieved.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("count visible via GetByEmailOrUsername", func(t *testing.T) {
+		retrieved, err := repo.GetByEmailOrUsername(ctx, "lockout_incr@example.com")
+		if err != nil {
+			t.Fatalf("Failed to get user by email/username: %v", err)
+		}
+		if retrieved.FailedLoginAttempts != 2 {
+			t.Errorf("Expected FailedLoginAttempts=2 via GetByEmailOrUsername, got %d", retrieved.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("count visible via GetByUsername", func(t *testing.T) {
+		retrieved, err := repo.GetByUsername(ctx, "lockout_incr")
+		if err != nil {
+			t.Fatalf("Failed to get user by username: %v", err)
+		}
+		if retrieved.FailedLoginAttempts != 2 {
+			t.Errorf("Expected FailedLoginAttempts=2 via GetByUsername, got %d", retrieved.FailedLoginAttempts)
+		}
+	})
+}
+
+func TestUserRepository_IncrementFailedLoginAttempts_ToThreshold(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_threshold@example.com'")
+
+	user := &models.User{
+		Username:     "lockout_threshold",
+		Email:        "lockout_threshold@example.com",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	// Increment exactly 10 times (the lockout threshold)
+	for i := 1; i <= 10; i++ {
+		count, err := repo.IncrementFailedLoginAttempts(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to increment at step %d: %v", i, err)
+		}
+		if count != i {
+			t.Errorf("Step %d: expected count %d, got %d", i, i, count)
+		}
+	}
+
+	// Verify final state
+	retrieved, err := repo.GetByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if retrieved.FailedLoginAttempts != 10 {
+		t.Errorf("Expected FailedLoginAttempts=10, got %d", retrieved.FailedLoginAttempts)
+	}
+
+	// Can increment beyond threshold (counter keeps going)
+	count, err := repo.IncrementFailedLoginAttempts(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("Failed to increment beyond threshold: %v", err)
+	}
+	if count != 11 {
+		t.Errorf("Expected count 11 beyond threshold, got %d", count)
+	}
+}
+
+func TestUserRepository_NewUserDefaults(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_defaults@example.com'")
+
+	user := &models.User{
+		Username:     "lockout_defaults",
+		Email:        "lockout_defaults@example.com",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	retrieved, err := repo.GetByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+
+	if retrieved.FailedLoginAttempts != 0 {
+		t.Errorf("New user should have FailedLoginAttempts=0, got %d", retrieved.FailedLoginAttempts)
+	}
+	if retrieved.LockedUntil != nil {
+		t.Errorf("New user should have LockedUntil=nil, got %v", retrieved.LockedUntil)
+	}
+}
+
+func TestUserRepository_LockAccount(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_lock@example.com'")
+
+	user := &models.User{
+		Username:     "lockout_lock",
+		Email:        "lockout_lock@example.com",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	t.Run("sets locked_until timestamp", func(t *testing.T) {
+		lockUntil := time.Now().Add(15 * time.Minute).UTC()
+		if err := repo.LockAccount(ctx, user.ID, lockUntil); err != nil {
+			t.Fatalf("Failed to lock account: %v", err)
+		}
+
+		retrieved, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if retrieved.LockedUntil == nil {
+			t.Fatal("Expected LockedUntil to be set")
+		}
+		// Allow 2-second tolerance for time comparison
+		diff := retrieved.LockedUntil.Sub(lockUntil)
+		if diff < -2*time.Second || diff > 2*time.Second {
+			t.Errorf("LockedUntil mismatch: expected ~%v, got %v", lockUntil, *retrieved.LockedUntil)
+		}
+	})
+
+	t.Run("overwrites existing lock with new time", func(t *testing.T) {
+		// First lock
+		firstLock := time.Now().Add(5 * time.Minute).UTC()
+		_ = repo.LockAccount(ctx, user.ID, firstLock)
+
+		// Second lock with a longer duration
+		secondLock := time.Now().Add(30 * time.Minute).UTC()
+		if err := repo.LockAccount(ctx, user.ID, secondLock); err != nil {
+			t.Fatalf("Failed to overwrite lock: %v", err)
+		}
+
+		retrieved, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if retrieved.LockedUntil == nil {
+			t.Fatal("Expected LockedUntil to be set")
+		}
+		diff := retrieved.LockedUntil.Sub(secondLock)
+		if diff < -2*time.Second || diff > 2*time.Second {
+			t.Errorf("Expected lock to be overwritten to ~%v, got %v", secondLock, *retrieved.LockedUntil)
+		}
+	})
+
+	t.Run("locked_until visible via GetByEmailOrUsername", func(t *testing.T) {
+		lockUntil := time.Now().Add(10 * time.Minute).UTC()
+		_ = repo.LockAccount(ctx, user.ID, lockUntil)
+
+		retrieved, err := repo.GetByEmailOrUsername(ctx, "lockout_lock@example.com")
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if retrieved.LockedUntil == nil {
+			t.Error("Expected LockedUntil to be visible via GetByEmailOrUsername")
+		}
+	})
+}
+
+func TestUserRepository_ResetFailedLoginAttempts(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_reset@example.com'")
+
+	user := &models.User{
+		Username:     "lockout_reset",
+		Email:        "lockout_reset@example.com",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	t.Run("clears both counter and lock", func(t *testing.T) {
+		// Increment a few times and lock
+		for i := 0; i < 5; i++ {
+			_, _ = repo.IncrementFailedLoginAttempts(ctx, user.ID)
+		}
+		_ = repo.LockAccount(ctx, user.ID, time.Now().Add(15*time.Minute))
+
+		// Verify pre-reset state
+		before, _ := repo.GetByID(ctx, user.ID)
+		if before.FailedLoginAttempts != 5 {
+			t.Fatalf("Pre-condition failed: expected 5 failed attempts, got %d", before.FailedLoginAttempts)
+		}
+		if before.LockedUntil == nil {
+			t.Fatal("Pre-condition failed: expected LockedUntil to be set")
+		}
+
+		// Reset
+		if err := repo.ResetFailedLoginAttempts(ctx, user.ID); err != nil {
+			t.Fatalf("Failed to reset: %v", err)
+		}
+
+		retrieved, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if retrieved.FailedLoginAttempts != 0 {
+			t.Errorf("Expected FailedLoginAttempts=0, got %d", retrieved.FailedLoginAttempts)
+		}
+		if retrieved.LockedUntil != nil {
+			t.Errorf("Expected LockedUntil to be nil, got %v", retrieved.LockedUntil)
+		}
+	})
+
+	t.Run("is idempotent on already-reset user", func(t *testing.T) {
+		// Reset on a user that's already at zero
+		if err := repo.ResetFailedLoginAttempts(ctx, user.ID); err != nil {
+			t.Fatalf("Failed to reset already-reset user: %v", err)
+		}
+
+		retrieved, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if retrieved.FailedLoginAttempts != 0 {
+			t.Errorf("Expected FailedLoginAttempts=0, got %d", retrieved.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("allows re-increment after reset", func(t *testing.T) {
+		// Reset first
+		_ = repo.ResetFailedLoginAttempts(ctx, user.ID)
+
+		// Increment again
+		count, err := repo.IncrementFailedLoginAttempts(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to increment after reset: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Expected count 1 after reset+increment, got %d", count)
+		}
+	})
+}
+
+func TestUserRepository_LockoutFields_InSearch(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_search@example.com'")
+
+	user := &models.User{
+		Username:     "lockout_search",
+		Email:        "lockout_search@example.com",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	// Set some lockout state
+	for i := 0; i < 3; i++ {
+		_, _ = repo.IncrementFailedLoginAttempts(ctx, user.ID)
+	}
+	lockUntil := time.Now().Add(10 * time.Minute).UTC()
+	_ = repo.LockAccount(ctx, user.ID, lockUntil)
+
+	// Search should scan lockout fields without error
+	users, total, err := repo.Search(ctx, "lockout_search", 1, 10)
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("Expected 1 search result, got %d", total)
+	}
+	if len(users) != 1 {
+		t.Fatalf("Expected 1 user, got %d", len(users))
+	}
+	if users[0].FailedLoginAttempts != 3 {
+		t.Errorf("Search result: expected FailedLoginAttempts=3, got %d", users[0].FailedLoginAttempts)
+	}
+	if users[0].LockedUntil == nil {
+		t.Error("Search result: expected LockedUntil to be set")
+	}
+}
+
+func TestUserRepository_LockoutFields_InGetByNormalizedEmail(t *testing.T) {
+	db := testDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE email = 'lockout_norm@example.com'")
+
+	normalizedEmail := "lockoutnorm@example.com"
+	user := &models.User{
+		Username:        "lockout_norm",
+		Email:           "lockout_norm@example.com",
+		PasswordHash:    "hash",
+		EmailNormalized: &normalizedEmail,
+	}
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID)
+	})
+
+	// Set lockout state
+	_, _ = repo.IncrementFailedLoginAttempts(ctx, user.ID)
+	_ = repo.LockAccount(ctx, user.ID, time.Now().Add(5*time.Minute))
+
+	retrieved, err := repo.GetByNormalizedEmail(ctx, normalizedEmail)
+	if err != nil {
+		t.Fatalf("GetByNormalizedEmail failed: %v", err)
+	}
+	if retrieved.FailedLoginAttempts != 1 {
+		t.Errorf("Expected FailedLoginAttempts=1, got %d", retrieved.FailedLoginAttempts)
+	}
+	if retrieved.LockedUntil == nil {
+		t.Error("Expected LockedUntil to be set")
+	}
+}

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -23,6 +23,22 @@ import (
 	"github.com/opencrr/communityrapidresponse.net/internal/services"
 )
 
+// Auth rate limit constants
+const (
+	authLoginLimit             = 10
+	authLoginWindow            = 5 * time.Minute
+	authRegisterLimit          = 3
+	authRegisterWindow         = 1 * time.Hour
+	authForgotPasswordLimit    = 5
+	authForgotPasswordWindow   = 15 * time.Minute
+	authResetPasswordLimit     = 10
+	authResetPasswordWindow    = 15 * time.Minute
+	authResendVerifyLimit      = 3
+	authResendVerifyWindow     = 15 * time.Minute
+	accountLockoutThreshold    = 10
+	accountLockoutDuration     = 15 * time.Minute
+)
+
 // EmailVerificationClaims represents JWT claims for email verification tokens
 type EmailVerificationClaims struct {
 	UserID string `json:"user_id"`
@@ -44,6 +60,37 @@ type AuthHandler struct {
 	emailTemplates    *services.EmailTemplates
 	baseURL           string
 	encryptionKeyRepo *database.EncryptionKeyRepository
+	rateLimiter       services.RateLimiter
+}
+
+// SetRateLimiter sets the rate limiter for auth-specific rate limiting.
+// This is optional - if not set, auth rate limits are not enforced.
+func (h *AuthHandler) SetRateLimiter(limiter services.RateLimiter) {
+	h.rateLimiter = limiter
+}
+
+// checkAuthRateLimit checks per-endpoint auth rate limits.
+// Returns true if the request is allowed, false if rate-limited (429 already written).
+func (h *AuthHandler) checkAuthRateLimit(w http.ResponseWriter, r *http.Request, action string, limit int, window time.Duration) bool {
+	if h.rateLimiter == nil {
+		return true
+	}
+
+	clientIP := middleware.GetClientIP(r)
+	key := fmt.Sprintf("auth:%s:%s", action, clientIP)
+
+	allowed, _, _, err := h.rateLimiter.Allow(r.Context(), key, limit, window)
+	if err != nil {
+		// On error, allow the request rather than blocking legitimate users
+		log.Printf("WARN: auth rate limit check failed for %s: %v", key, err)
+		return true
+	}
+
+	if !allowed {
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "Too many requests. Please try again later.")
+		return false
+	}
+	return true
 }
 
 // NewAuthHandler creates a new auth handler
@@ -99,6 +146,10 @@ func NewAuthHandlerWithEmailService(
 
 // Register handles user registration
 func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
+	if !h.checkAuthRateLimit(w, r, "register", authRegisterLimit, authRegisterWindow) {
+		return
+	}
+
 	var req models.RegisterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request", "Invalid request body")
@@ -208,6 +259,10 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 
 // Login handles user login
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	if !h.checkAuthRateLimit(w, r, "login", authLoginLimit, authLoginWindow) {
+		return
+	}
+
 	var req models.LoginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request", "Invalid request body")
@@ -246,8 +301,34 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if account is locked
+	if user.LockedUntil != nil && time.Now().Before(*user.LockedUntil) {
+		appSentry.IncrementCounter("auth.login_failure", 1, "reason", "account_locked")
+		writeError(w, http.StatusTooManyRequests, "account_locked", "Account is temporarily locked due to too many failed login attempts. Please try again later.")
+		return
+	}
+
 	// Check password
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+		// Increment failed login counter
+		failedCount, incrErr := h.userRepo.IncrementFailedLoginAttempts(r.Context(), user.ID)
+		if incrErr != nil {
+			log.Printf("WARN: failed to increment login attempts for user %s: %v", user.ID, incrErr)
+		}
+
+		// Lock account if threshold exceeded
+		if failedCount >= accountLockoutThreshold {
+			lockUntil := time.Now().Add(accountLockoutDuration)
+			if lockErr := h.userRepo.LockAccount(r.Context(), user.ID, lockUntil); lockErr != nil {
+				log.Printf("WARN: failed to lock account for user %s: %v", user.ID, lockErr)
+			}
+			if h.auditRepo != nil {
+				logAuditError(r, h.auditRepo.Log(r.Context(), &user.ID, models.AuditActionAccountLocked, nil, nil, map[string]string{
+					"failed_attempts": fmt.Sprintf("%d", failedCount),
+				}), "account_locked")
+			}
+		}
+
 		// Audit log: login failed (wrong password)
 		if h.auditRepo != nil {
 			logAuditError(r, h.auditRepo.Log(r.Context(), &user.ID, models.AuditActionUserLoginFailed, nil, nil, map[string]string{
@@ -257,6 +338,13 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		appSentry.IncrementCounter("auth.login_failure", 1, "reason", "invalid_password")
 		writeError(w, http.StatusUnauthorized, "invalid_credentials", "Invalid credentials")
 		return
+	}
+
+	// Reset failed login attempts on successful password verification
+	if user.FailedLoginAttempts > 0 {
+		if resetErr := h.userRepo.ResetFailedLoginAttempts(r.Context(), user.ID); resetErr != nil {
+			log.Printf("WARN: failed to reset login attempts for user %s: %v", user.ID, resetErr)
+		}
 	}
 
 	// Determine token type based on email verification and MFA status
@@ -504,6 +592,10 @@ func (h *AuthHandler) VerifyEmail(w http.ResponseWriter, r *http.Request) {
 
 // ResendVerificationEmail resends the verification email
 func (h *AuthHandler) ResendVerificationEmail(w http.ResponseWriter, r *http.Request) {
+	if !h.checkAuthRateLimit(w, r, "resend-verification", authResendVerifyLimit, authResendVerifyWindow) {
+		return
+	}
+
 	claims := middleware.GetUserFromContext(r.Context())
 	if claims == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
@@ -618,6 +710,10 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 
 // ForgotPassword handles password reset request (sends email with reset link)
 func (h *AuthHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
+	if !h.checkAuthRateLimit(w, r, "forgot-password", authForgotPasswordLimit, authForgotPasswordWindow) {
+		return
+	}
+
 	var req struct {
 		Email string `json:"email"`
 	}
@@ -725,6 +821,10 @@ func (h *AuthHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 
 // ResetPassword handles password reset with a valid token
 func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	if !h.checkAuthRateLimit(w, r, "reset-password", authResetPasswordLimit, authResetPasswordWindow) {
+		return
+	}
+
 	var req struct {
 		Token    string `json:"token"`
 		Password string `json:"password"`

--- a/internal/handlers/auth_ratelimit_test.go
+++ b/internal/handlers/auth_ratelimit_test.go
@@ -1,0 +1,735 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/opencrr/communityrapidresponse.net/internal/database"
+	"github.com/opencrr/communityrapidresponse.net/internal/models"
+	"github.com/opencrr/communityrapidresponse.net/internal/services"
+)
+
+func TestAuthHandler_CheckAuthRateLimit(t *testing.T) {
+	userRepo := database.NewUserRepository(testDB(t))
+	jwtAuth := testJWTAuth()
+	handler := NewAuthHandler(userRepo, jwtAuth)
+
+	t.Run("allows request when no rate limiter set", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+		rec := httptest.NewRecorder()
+
+		allowed := handler.checkAuthRateLimit(rec, req, "login", 10, 5*time.Minute)
+		if !allowed {
+			t.Error("Expected request to be allowed when rate limiter is nil")
+		}
+	})
+
+	t.Run("allows request within limit", func(t *testing.T) {
+		limiter := services.NewInMemoryRateLimiter()
+		handler.SetRateLimiter(limiter)
+		defer func() { handler.rateLimiter = nil }()
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+		req.RemoteAddr = "192.168.1.1:12345"
+		rec := httptest.NewRecorder()
+
+		allowed := handler.checkAuthRateLimit(rec, req, "login", 10, 5*time.Minute)
+		if !allowed {
+			t.Error("Expected request to be allowed")
+		}
+	})
+
+	t.Run("blocks request over limit", func(t *testing.T) {
+		limiter := services.NewInMemoryRateLimiter()
+		handler.SetRateLimiter(limiter)
+		defer func() { handler.rateLimiter = nil }()
+
+		// Exhaust the limit
+		for i := 0; i < 3; i++ {
+			req := httptest.NewRequest("POST", "/api/v1/auth/register", nil)
+			req.RemoteAddr = "10.0.0.1:12345"
+			rec := httptest.NewRecorder()
+			allowed := handler.checkAuthRateLimit(rec, req, "register", 3, 1*time.Hour)
+			if !allowed {
+				t.Fatalf("Expected request %d to be allowed", i+1)
+			}
+		}
+
+		// This should be blocked
+		req := httptest.NewRequest("POST", "/api/v1/auth/register", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		rec := httptest.NewRecorder()
+		allowed := handler.checkAuthRateLimit(rec, req, "register", 3, 1*time.Hour)
+		if allowed {
+			t.Error("Expected request to be rate limited")
+		}
+		if rec.Code != http.StatusTooManyRequests {
+			t.Errorf("Expected status 429, got %d", rec.Code)
+		}
+
+		var resp ErrorResponse
+		_ = json.NewDecoder(rec.Body).Decode(&resp)
+		if resp.Error != "rate_limited" {
+			t.Errorf("Expected error code 'rate_limited', got '%s'", resp.Error)
+		}
+	})
+
+	t.Run("different actions have separate limits", func(t *testing.T) {
+		limiter := services.NewInMemoryRateLimiter()
+		handler.SetRateLimiter(limiter)
+		defer func() { handler.rateLimiter = nil }()
+
+		// Exhaust login limit
+		for i := 0; i < 2; i++ {
+			req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+			req.RemoteAddr = "10.0.0.2:12345"
+			rec := httptest.NewRecorder()
+			handler.checkAuthRateLimit(rec, req, "login", 2, 5*time.Minute)
+		}
+
+		// Register from same IP should still work
+		req := httptest.NewRequest("POST", "/api/v1/auth/register", nil)
+		req.RemoteAddr = "10.0.0.2:12345"
+		rec := httptest.NewRecorder()
+		allowed := handler.checkAuthRateLimit(rec, req, "register", 3, 1*time.Hour)
+		if !allowed {
+			t.Error("Expected register to be allowed (separate from login limit)")
+		}
+	})
+
+	t.Run("different IPs have separate limits", func(t *testing.T) {
+		limiter := services.NewInMemoryRateLimiter()
+		handler.SetRateLimiter(limiter)
+		defer func() { handler.rateLimiter = nil }()
+
+		// Exhaust limit for IP1
+		for i := 0; i < 2; i++ {
+			req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+			req.RemoteAddr = "10.0.0.10:12345"
+			rec := httptest.NewRecorder()
+			handler.checkAuthRateLimit(rec, req, "login", 2, 5*time.Minute)
+		}
+
+		// IP1 should be blocked
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+		req.RemoteAddr = "10.0.0.10:12345"
+		rec := httptest.NewRecorder()
+		blocked := handler.checkAuthRateLimit(rec, req, "login", 2, 5*time.Minute)
+		if blocked {
+			t.Error("Expected IP1 to be rate limited")
+		}
+
+		// IP2 should still be allowed
+		req2 := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+		req2.RemoteAddr = "10.0.0.11:12345"
+		rec2 := httptest.NewRecorder()
+		allowed := handler.checkAuthRateLimit(rec2, req2, "login", 2, 5*time.Minute)
+		if !allowed {
+			t.Error("Expected IP2 to be allowed (separate from IP1)")
+		}
+	})
+}
+
+func TestAuthHandler_LoginRateLimit(t *testing.T) {
+	db := testDB(t)
+	userRepo := database.NewUserRepository(db)
+	jwtAuth := testJWTAuth()
+	handler := NewAuthHandler(userRepo, jwtAuth)
+
+	limiter := services.NewInMemoryRateLimiter()
+	handler.SetRateLimiter(limiter)
+
+	// Make 10 login requests (at the limit) - use non-existent emails to avoid lockout
+	for i := 0; i < 10; i++ {
+		body := map[string]string{
+			"email":    "nonexistent@loginrltest.com",
+			"password": "anypassword12345",
+		}
+		bodyBytes, _ := json.Marshal(body)
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "172.16.1.1:12345"
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+		// These should return 401 (invalid credentials), not 429
+		if rec.Code == http.StatusTooManyRequests {
+			t.Fatalf("Request %d: expected 401 (within limit), got 429", i+1)
+		}
+	}
+
+	// 11th request should be rate limited
+	body := map[string]string{
+		"email":    "nonexistent@loginrltest.com",
+		"password": "anypassword12345",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "172.16.1.1:12345"
+	rec := httptest.NewRecorder()
+	handler.Login(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited login, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ErrorResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.Error != "rate_limited" {
+		t.Errorf("Expected error 'rate_limited', got '%s'", resp.Error)
+	}
+}
+
+func TestAuthHandler_ForgotPasswordRateLimit(t *testing.T) {
+	db := testDB(t)
+	userRepo := database.NewUserRepository(db)
+	jwtAuth := testJWTAuth()
+	// Construct with nil passwordResetRepo - requests will pass rate limit
+	// but fail with 503. We just verify the 6th gets 429 before reaching handler logic.
+	handler := NewAuthHandler(userRepo, jwtAuth)
+
+	limiter := services.NewInMemoryRateLimiter()
+	handler.SetRateLimiter(limiter)
+
+	// Make 5 requests (at the limit)
+	for i := 0; i < 5; i++ {
+		body := map[string]string{"email": "test@forgotrltest.com"}
+		bodyBytes, _ := json.Marshal(body)
+		req := httptest.NewRequest("POST", "/api/v1/auth/forgot-password", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "172.16.2.1:12345"
+		rec := httptest.NewRecorder()
+		handler.ForgotPassword(rec, req)
+		// These will return 503 (password reset not configured) but rate limit is consumed
+		if rec.Code == http.StatusTooManyRequests {
+			t.Fatalf("Request %d: should not be rate limited yet", i+1)
+		}
+	}
+
+	// 6th request should be rate limited
+	body := map[string]string{"email": "test@forgotrltest.com"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/v1/auth/forgot-password", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "172.16.2.1:12345"
+	rec := httptest.NewRecorder()
+	handler.ForgotPassword(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited forgot-password, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthHandler_ResetPasswordRateLimit(t *testing.T) {
+	db := testDB(t)
+	userRepo := database.NewUserRepository(db)
+	jwtAuth := testJWTAuth()
+	handler := NewAuthHandler(userRepo, jwtAuth)
+
+	limiter := services.NewInMemoryRateLimiter()
+	handler.SetRateLimiter(limiter)
+
+	// Make 10 requests (at the limit)
+	for i := 0; i < 10; i++ {
+		body := map[string]string{
+			"token":    "invalid_token",
+			"password": "newpassword12345",
+		}
+		bodyBytes, _ := json.Marshal(body)
+		req := httptest.NewRequest("POST", "/api/v1/auth/reset-password", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "172.16.3.1:12345"
+		rec := httptest.NewRecorder()
+		handler.ResetPassword(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			t.Fatalf("Request %d: should not be rate limited yet", i+1)
+		}
+	}
+
+	// 11th request should be rate limited
+	body := map[string]string{
+		"token":    "invalid_token",
+		"password": "newpassword12345",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/v1/auth/reset-password", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "172.16.3.1:12345"
+	rec := httptest.NewRecorder()
+	handler.ResetPassword(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited reset-password, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthHandler_AccountLockout(t *testing.T) {
+	db := testDB(t)
+	userRepo := database.NewUserRepository(db)
+	auditRepo := database.NewAuditRepository(db)
+	jwtAuth := testJWTAuth()
+	handler := NewAuthHandlerWithEmailService(
+		db, userRepo, jwtAuth, nil, "test_secret_key_at_least_32_characters_long",
+		false, false, auditRepo, nil, nil, "http://localhost:3000", nil,
+	)
+
+	// Create a test user
+	_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@lockouttest.com'")
+	registerBody := map[string]string{
+		"username": "lockouttest",
+		"email":    "user@lockouttest.com",
+		"password": "securepassword123",
+	}
+	registerBytes, _ := json.Marshal(registerBody)
+	registerReq := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewReader(registerBytes))
+	registerReq.Header.Set("Content-Type", "application/json")
+	registerRec := httptest.NewRecorder()
+	handler.Register(registerRec, registerReq)
+
+	var registerResp models.RegisterResponse
+	_ = json.NewDecoder(registerRec.Body).Decode(&registerResp)
+
+	// Disable MFA
+	_, _ = db.ExecContext(context.Background(), "UPDATE users SET mfa_setup_required = FALSE, mfa_enabled = FALSE WHERE id = ?", registerResp.UserID)
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", registerResp.UserID)
+	})
+
+	t.Run("increments failed attempts on wrong password", func(t *testing.T) {
+		// Reset counter first
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = ?", registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "wrongpassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", rec.Code)
+		}
+
+		// Check that failed_login_attempts was incremented
+		user, err := userRepo.GetByID(context.Background(), registerResp.UserID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if user.FailedLoginAttempts != 1 {
+			t.Errorf("Expected FailedLoginAttempts=1, got %d", user.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("locks account after threshold", func(t *testing.T) {
+		// Set counter to just below threshold
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 9, locked_until = NULL WHERE id = ?", registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "wrongpassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", rec.Code)
+		}
+
+		// Check that account is now locked
+		user, err := userRepo.GetByID(context.Background(), registerResp.UserID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if user.LockedUntil == nil {
+			t.Error("Expected account to be locked after 10 failed attempts")
+		}
+		if user.FailedLoginAttempts != 10 {
+			t.Errorf("Expected FailedLoginAttempts=10, got %d", user.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("rejects login for locked account", func(t *testing.T) {
+		// Ensure account is locked
+		lockUntil := time.Now().Add(15 * time.Minute)
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 10, locked_until = ? WHERE id = ?", lockUntil, registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "securepassword123", // Correct password
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusTooManyRequests {
+			t.Errorf("Expected status 429, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var resp ErrorResponse
+		_ = json.NewDecoder(rec.Body).Decode(&resp)
+		if resp.Error != "account_locked" {
+			t.Errorf("Expected error 'account_locked', got '%s'", resp.Error)
+		}
+	})
+
+	t.Run("allows login after lock expires", func(t *testing.T) {
+		// Set lock to the past
+		lockUntil := time.Now().Add(-1 * time.Minute)
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 10, locked_until = ? WHERE id = ?", lockUntil, registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "securepassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("resets failed attempts on successful login", func(t *testing.T) {
+		// Set some failed attempts
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 5, locked_until = NULL WHERE id = ?", registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "securepassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		// Verify counter was reset
+		user, err := userRepo.GetByID(context.Background(), registerResp.UserID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if user.FailedLoginAttempts != 0 {
+			t.Errorf("Expected FailedLoginAttempts=0 after successful login, got %d", user.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("no lockout increment for nonexistent user", func(t *testing.T) {
+		body := map[string]string{
+			"email":    "doesnotexist@lockouttest.com",
+			"password": "anypassword12345",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		// Should return 401 without incrementing any counter (no user to increment)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("lockout works with username login", func(t *testing.T) {
+		// Reset counter
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 9, locked_until = NULL WHERE id = ?", registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "lockouttest", // Using username
+			"password": "wrongpassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", rec.Code)
+		}
+
+		// Verify lockout was triggered
+		user, err := userRepo.GetByID(context.Background(), registerResp.UserID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if user.LockedUntil == nil {
+			t.Error("Expected account to be locked via username login")
+		}
+		if user.FailedLoginAttempts != 10 {
+			t.Errorf("Expected FailedLoginAttempts=10, got %d", user.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("locked account rejects wrong password with account_locked", func(t *testing.T) {
+		// Lock the account
+		lockUntil := time.Now().Add(15 * time.Minute)
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 10, locked_until = ? WHERE id = ?", lockUntil, registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "wrongpassword123", // Wrong password on locked account
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		// Should return 429 account_locked (lockout check is before password check)
+		if rec.Code != http.StatusTooManyRequests {
+			t.Errorf("Expected status 429 for locked account with wrong password, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var resp ErrorResponse
+		_ = json.NewDecoder(rec.Body).Decode(&resp)
+		if resp.Error != "account_locked" {
+			t.Errorf("Expected error 'account_locked', got '%s'", resp.Error)
+		}
+	})
+
+	t.Run("multiple lockout cycles", func(t *testing.T) {
+		// Reset everything
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = ?", registerResp.UserID)
+
+		// First cycle: fail 10 times to trigger lockout
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 9 WHERE id = ?", registerResp.UserID)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "wrongpassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		// Verify locked
+		user, _ := userRepo.GetByID(context.Background(), registerResp.UserID)
+		if user.LockedUntil == nil {
+			t.Fatal("Expected account to be locked after first cycle")
+		}
+
+		// Expire lock, then login successfully to reset
+		lockPast := time.Now().Add(-1 * time.Minute)
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET locked_until = ? WHERE id = ?", lockPast, registerResp.UserID)
+
+		body["password"] = "securepassword123"
+		bodyBytes, _ = json.Marshal(body)
+		req = httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec = httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("Expected successful login after lock expired, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		// Verify counter was reset
+		user, _ = userRepo.GetByID(context.Background(), registerResp.UserID)
+		if user.FailedLoginAttempts != 0 {
+			t.Errorf("Expected FailedLoginAttempts=0 after successful login, got %d", user.FailedLoginAttempts)
+		}
+		if user.LockedUntil != nil {
+			t.Error("Expected LockedUntil to be nil after successful login")
+		}
+
+		// Second cycle: fail 10 times again
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 9 WHERE id = ?", registerResp.UserID)
+
+		body["password"] = "wrongpassword123"
+		bodyBytes, _ = json.Marshal(body)
+		req = httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec = httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		// Verify locked again
+		user, _ = userRepo.GetByID(context.Background(), registerResp.UserID)
+		if user.LockedUntil == nil {
+			t.Error("Expected account to be locked after second cycle")
+		}
+		if user.FailedLoginAttempts != 10 {
+			t.Errorf("Expected FailedLoginAttempts=10 in second cycle, got %d", user.FailedLoginAttempts)
+		}
+	})
+
+	t.Run("creates audit log entry on lockout", func(t *testing.T) {
+		// Reset counter
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 9, locked_until = NULL WHERE id = ?", registerResp.UserID)
+		// Delete existing audit entries for clean test
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM audit_log WHERE user_id = ? AND action = ?", registerResp.UserID, models.AuditActionAccountLocked)
+
+		body := map[string]string{
+			"email":    "user@lockouttest.com",
+			"password": "wrongpassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.Login(rec, req)
+
+		// Verify audit log entry was created
+		var auditCount int
+		err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM audit_log WHERE user_id = ? AND action = ?",
+			registerResp.UserID, models.AuditActionAccountLocked,
+		).Scan(&auditCount)
+		if err != nil {
+			t.Fatalf("Failed to query audit log: %v", err)
+		}
+		if auditCount == 0 {
+			t.Error("Expected audit log entry for account_locked action")
+		}
+	})
+}
+
+func TestAuthHandler_RegisterRateLimit(t *testing.T) {
+	db := testDB(t)
+	userRepo := database.NewUserRepository(db)
+	jwtAuth := testJWTAuth()
+	handler := NewAuthHandler(userRepo, jwtAuth)
+
+	limiter := services.NewInMemoryRateLimiter()
+	handler.SetRateLimiter(limiter)
+
+	// Clean up test users
+	_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@ratelimittest.com'")
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@ratelimittest.com'")
+	})
+
+	// Make 3 registration requests (at the limit)
+	for i := 0; i < 3; i++ {
+		body := map[string]string{
+			"username": "invalid", // Will fail validation but rate limit still counts
+			"email":    "",
+			"password": "",
+		}
+		bodyBytes, _ := json.Marshal(body)
+		req := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "172.16.0.1:12345"
+		rec := httptest.NewRecorder()
+		handler.Register(rec, req)
+		// Don't check status - we just want to consume rate limit tokens
+	}
+
+	// 4th request should be rate limited
+	body := map[string]string{
+		"username": "ratelimited",
+		"email":    "ratelimited@ratelimittest.com",
+		"password": "securepassword123",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "172.16.0.1:12345"
+	rec := httptest.NewRecorder()
+	handler.Register(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited register, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthHandler_LockoutAndRateLimitIndependent(t *testing.T) {
+	db := testDB(t)
+	userRepo := database.NewUserRepository(db)
+	auditRepo := database.NewAuditRepository(db)
+	jwtAuth := testJWTAuth()
+	handler := NewAuthHandlerWithEmailService(
+		db, userRepo, jwtAuth, nil, "test_secret_key_at_least_32_characters_long",
+		false, false, auditRepo, nil, nil, "http://localhost:3000", nil,
+	)
+
+	limiter := services.NewInMemoryRateLimiter()
+	handler.SetRateLimiter(limiter)
+
+	// Create a test user
+	_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@lockrl.com'")
+	registerBody := map[string]string{
+		"username": "lockrltest",
+		"email":    "user@lockrl.com",
+		"password": "securepassword123",
+	}
+	registerBytes, _ := json.Marshal(registerBody)
+	registerReq := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewReader(registerBytes))
+	registerReq.Header.Set("Content-Type", "application/json")
+	registerRec := httptest.NewRecorder()
+	handler.Register(registerRec, registerReq)
+
+	var registerResp models.RegisterResponse
+	_ = json.NewDecoder(registerRec.Body).Decode(&registerResp)
+
+	_, _ = db.ExecContext(context.Background(), "UPDATE users SET mfa_setup_required = FALSE, mfa_enabled = FALSE WHERE id = ?", registerResp.UserID)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", registerResp.UserID)
+	})
+
+	t.Run("lockout triggers before IP rate limit is exhausted", func(t *testing.T) {
+		// Reset state
+		_, _ = db.ExecContext(context.Background(), "UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = ?", registerResp.UserID)
+
+		// Lockout threshold is 10, login rate limit is also 10
+		// After 10 failed attempts: account is locked, and rate limit is exhausted
+		for i := 0; i < 10; i++ {
+			body := map[string]string{
+				"email":    "user@lockrl.com",
+				"password": "wrongpassword123",
+			}
+			bodyBytes, _ := json.Marshal(body)
+			req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader(bodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+			req.RemoteAddr = "172.16.5.1:12345"
+			rec := httptest.NewRecorder()
+			handler.Login(rec, req)
+
+			if rec.Code == http.StatusTooManyRequests {
+				t.Fatalf("Request %d: got rate limited before lockout, expected 401", i+1)
+			}
+		}
+
+		// Verify account is locked
+		user, err := userRepo.GetByID(context.Background(), registerResp.UserID)
+		if err != nil {
+			t.Fatalf("Failed to get user: %v", err)
+		}
+		if user.LockedUntil == nil {
+			t.Error("Expected account to be locked after 10 wrong attempts")
+		}
+	})
+}

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -130,6 +130,9 @@ const (
 	AuditActionMeshtasticChannelCreated = "meshtastic_channel_created"
 	AuditActionMeshtasticChannelUpdated = "meshtastic_channel_updated"
 	AuditActionMeshtasticChannelDeleted = "meshtastic_channel_deleted"
+
+	// Account lockout
+	AuditActionAccountLocked = "account_locked"
 )
 
 // AuditLogFilter represents filters for querying audit logs

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -35,8 +35,10 @@ type User struct {
 	BlockReason   *string    `json:"block_reason,omitempty" db:"block_reason"`
 	AddressHash      *string          `json:"-" db:"address_hash"` // SHA-256 hash of verified address (never exposed)
 	CreatedAt        time.Time        `json:"created_at" db:"created_at"`
-	LastLogin        *time.Time       `json:"last_login,omitempty" db:"last_login"`
-	DeletedAt        *time.Time       `json:"-" db:"deleted_at"`
+	LastLogin            *time.Time       `json:"last_login,omitempty" db:"last_login"`
+	DeletedAt            *time.Time       `json:"-" db:"deleted_at"`
+	FailedLoginAttempts  int              `json:"-" db:"failed_login_attempts"`
+	LockedUntil          *time.Time       `json:"-" db:"locked_until"`
 }
 
 // UserRegion represents a user's membership in a geographic region

--- a/migrations/029_account_lockout.down.sql
+++ b/migrations/029_account_lockout.down.sql
@@ -1,0 +1,4 @@
+-- Remove account lockout columns
+ALTER TABLE users
+    DROP COLUMN failed_login_attempts,
+    DROP COLUMN locked_until;

--- a/migrations/029_account_lockout.up.sql
+++ b/migrations/029_account_lockout.up.sql
@@ -1,0 +1,4 @@
+-- Add account lockout columns for brute-force protection
+ALTER TABLE users
+    ADD COLUMN failed_login_attempts INT NOT NULL DEFAULT 0,
+    ADD COLUMN locked_until TIMESTAMP NULL DEFAULT NULL;

--- a/tests/auth_ratelimit_e2e_test.go
+++ b/tests/auth_ratelimit_e2e_test.go
@@ -1,0 +1,540 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/opencrr/communityrapidresponse.net/internal/config"
+	"github.com/opencrr/communityrapidresponse.net/internal/database"
+	"github.com/opencrr/communityrapidresponse.net/internal/handlers"
+	"github.com/opencrr/communityrapidresponse.net/internal/middleware"
+	"github.com/opencrr/communityrapidresponse.net/internal/mocks"
+	"github.com/opencrr/communityrapidresponse.net/internal/models"
+	"github.com/opencrr/communityrapidresponse.net/internal/services"
+)
+
+// AuthRateLimitTestSuite holds dependencies for auth-specific rate limit E2E tests
+type AuthRateLimitTestSuite struct {
+	t        *testing.T
+	db       *database.DB
+	server   *httptest.Server
+	userRepo *database.UserRepository
+	limiter  services.RateLimiter
+}
+
+// SetupAuthRateLimitE2ETest creates a test suite with auth-specific rate limiting enabled.
+// Global rate limiting is set high so it does not interfere.
+func SetupAuthRateLimitE2ETest(t *testing.T) *AuthRateLimitTestSuite {
+	host := os.Getenv("TEST_DB_HOST")
+	if host == "" {
+		t.Skip("TEST_DB_HOST not set, skipping auth rate limit e2e tests")
+	}
+
+	port := 3306
+	if p := os.Getenv("TEST_DB_PORT"); p != "" {
+		_, _ = fmt.Sscanf(p, "%d", &port)
+	}
+
+	cfg := &config.DatabaseConfig{
+		Host:     host,
+		Port:     port,
+		User:     getEnvOrDefault("TEST_DB_USER", "test"),
+		Password: getEnvOrDefault("TEST_DB_PASSWORD", "testpassword"),
+		Name:     getEnvOrDefault("TEST_DB_NAME", "communityrapidresponse_test"),
+		Charset:  "utf8mb4",
+	}
+
+	db, err := database.New(cfg)
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+
+	// Create repositories
+	userRepo := database.NewUserRepository(db)
+	regionRepo := database.NewRegionRepository(db)
+	verifyRepo := database.NewVerificationRepository(db)
+	vouchRepo := database.NewVouchRepository(db)
+	groupRepo := database.NewSignalGroupRepository(db)
+	membershipRepo := database.NewMembershipRepository(db)
+	schoolRepo := database.NewSchoolRepository(db)
+	districtRepo := database.NewSchoolDistrictRepository(db)
+	schoolVouchRepo := database.NewSchoolVouchRepository(db)
+	auditRepo := database.NewAuditRepository(db)
+
+	// Create JWT auth
+	jwtConfig := &config.JWTConfig{
+		Secret:          "test_secret_key_at_least_32_characters_long",
+		ExpirationHours: 24,
+		Issuer:          "test_issuer",
+	}
+	jwtAuth := middleware.NewJWTAuth(jwtConfig)
+
+	// Create mock services
+	mockPostgrid := mocks.NewMockPostgridService()
+	mockMapbox := mocks.NewMockMapboxService()
+
+	// Create auth handler WITH full constructor (needed for lockout, which uses auditRepo + db)
+	authHandler := handlers.NewAuthHandlerWithEmailService(
+		db, userRepo, jwtAuth, nil, jwtConfig.Secret,
+		false, false, auditRepo, nil, nil, "http://localhost:3000", nil,
+	)
+
+	// Set up auth-specific rate limiter
+	limiter := services.NewInMemoryRateLimiter()
+	authHandler.SetRateLimiter(limiter)
+
+	// Create other handlers
+	regionHandler := handlers.NewRegionHandler(regionRepo, mockMapbox, nil)
+	verificationHandler := handlers.NewVerificationHandler(
+		nil, verifyRepo, vouchRepo, userRepo, regionRepo,
+		mockPostgrid, mockMapbox, nil,
+		false, 30,
+	)
+	consensusConfig := &config.ConsensusConfig{VotePercent: 50, VoteFloor: 3}
+	signalGroupHandler := handlers.NewSignalGroupHandler(
+		nil, groupRepo, nil, regionRepo, nil,
+	)
+	adminHandler := handlers.NewAdminHandler(userRepo, regionRepo, nil)
+
+	mfaConfig := &config.MFAConfig{
+		EncryptionKey: "01234567890123456789012345678901",
+		Issuer:        "Test MFA",
+	}
+	mfaService, _ := services.NewMFAService(mfaConfig)
+	mfaHandler := handlers.NewMFAHandler(nil, userRepo, mfaService, jwtAuth, false, nil)
+	membershipHandler := handlers.NewMembershipHandler(nil, membershipRepo, regionRepo, userRepo, nil)
+
+	blocklistConfig := &config.BlocklistConfig{
+		AddressBlocklistDuration:  2 * 365 * 24 * time.Hour,
+		ProposalRateLimitPerMonth: 5,
+	}
+	blocklistProposalRepo := database.NewBlocklistProposalRepository(db, blocklistConfig)
+	blocklistProposalHandler := handlers.NewBlocklistProposalHandler(
+		nil, blocklistProposalRepo, regionRepo, userRepo, nil, consensusConfig, blocklistConfig,
+	)
+
+	schoolHandler := handlers.NewSchoolHandler(
+		db, schoolRepo, districtRepo, schoolVouchRepo, groupRepo, nil,
+		userRepo, auditRepo, nil, consensusConfig, false, 0,
+	)
+
+	// Create router WITHOUT global rate limiting (pass nil) so only auth rate limits apply
+	router := handlers.NewRouter(
+		authHandler, mfaHandler, regionHandler, signalGroupHandler, verificationHandler, adminHandler,
+		membershipHandler, blocklistProposalHandler, nil, schoolHandler, nil, nil, nil, nil, jwtAuth, nil, nil, nil,
+		[]string{"*"}, nil,
+	)
+	handler := router.Setup()
+
+	server := httptest.NewServer(handler)
+
+	suite := &AuthRateLimitTestSuite{
+		t:        t,
+		db:       db,
+		server:   server,
+		userRepo: userRepo,
+		limiter:  limiter,
+	}
+
+	t.Cleanup(func() {
+		server.Close()
+		_ = db.Close()
+	})
+
+	return suite
+}
+
+func (s *AuthRateLimitTestSuite) postJSON(path string, body interface{}) *http.Response {
+	bodyBytes, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", s.server.URL+path, bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.t.Fatalf("Request failed: %v", err)
+	}
+	return resp
+}
+
+// registerAndLogin creates a test user, disables MFA, and returns the userID.
+func (s *AuthRateLimitTestSuite) registerAndLogin(username, email, password string) string {
+	resp := s.postJSON("/api/v1/auth/register", map[string]string{
+		"username": username, "email": email, "password": password,
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	var registerResp models.RegisterResponse
+	_ = json.NewDecoder(resp.Body).Decode(&registerResp)
+	userID := registerResp.UserID
+
+	if userID == "" {
+		var id string
+		_ = s.db.QueryRowContext(context.Background(), "SELECT id FROM users WHERE email = ?", email).Scan(&id)
+		userID = id
+	}
+
+	// Disable MFA
+	_, _ = s.db.ExecContext(context.Background(),
+		"UPDATE users SET mfa_setup_required = FALSE, mfa_enabled = FALSE WHERE id = ?", userID)
+
+	return userID
+}
+
+// ============================================
+// E2E Tests - Auth Rate Limiting
+// ============================================
+
+func TestE2E_AuthRateLimit_LoginBlocked(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	// Login rate limit is 10 per 5 minutes
+	// Make 10 login requests with a nonexistent email
+	for i := 0; i < 10; i++ {
+		resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+			"email":    "nonexistent@authrltest.com",
+			"password": "anypassword12345",
+		})
+		statusCode := resp.StatusCode
+		_ = resp.Body.Close()
+
+		if statusCode == http.StatusTooManyRequests {
+			t.Fatalf("Request %d: got rate limited too early, expected 401", i+1)
+		}
+		if statusCode != http.StatusUnauthorized {
+			t.Fatalf("Request %d: expected 401, got %d", i+1, statusCode)
+		}
+	}
+
+	// 11th request should be rate limited
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "nonexistent@authrltest.com",
+		"password": "anypassword12345",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited login, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["error"] != "rate_limited" {
+		t.Errorf("Expected error 'rate_limited', got '%v'", body["error"])
+	}
+}
+
+func TestE2E_AuthRateLimit_RegisterBlocked(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	// Clean up test users
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@authregrltest.com'")
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@authregrltest.com'")
+	})
+
+	// Register rate limit is 3 per hour
+	for i := 0; i < 3; i++ {
+		resp := suite.postJSON("/api/v1/auth/register", map[string]string{
+			"username": fmt.Sprintf("regrl%d", i),
+			"email":    fmt.Sprintf("regrl%d@authregrltest.com", i),
+			"password": "securepassword123",
+		})
+		statusCode := resp.StatusCode
+		_ = resp.Body.Close()
+
+		if statusCode == http.StatusTooManyRequests {
+			t.Fatalf("Request %d: got rate limited too early", i+1)
+		}
+	}
+
+	// 4th registration should be rate limited
+	resp := suite.postJSON("/api/v1/auth/register", map[string]string{
+		"username": "regrlblocked",
+		"email":    "regrlblocked@authregrltest.com",
+		"password": "securepassword123",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited register, got %d", resp.StatusCode)
+	}
+}
+
+func TestE2E_AuthRateLimit_ForgotPasswordBlocked(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	// ForgotPassword rate limit is 5 per 15 minutes
+	// Handler will return 503 (password reset not configured) but rate limit is consumed
+	for i := 0; i < 5; i++ {
+		resp := suite.postJSON("/api/v1/auth/forgot-password", map[string]string{
+			"email": "test@forgotrltest.com",
+		})
+		statusCode := resp.StatusCode
+		_ = resp.Body.Close()
+
+		if statusCode == http.StatusTooManyRequests {
+			t.Fatalf("Request %d: got rate limited too early", i+1)
+		}
+	}
+
+	// 6th request should be rate limited
+	resp := suite.postJSON("/api/v1/auth/forgot-password", map[string]string{
+		"email": "test@forgotrltest.com",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429 for rate-limited forgot-password, got %d", resp.StatusCode)
+	}
+}
+
+func TestE2E_AuthRateLimit_AccountLockoutAccumulates(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	// Clean up and register a user
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2elockout1.com'")
+	userID := suite.registerAndLogin("e2elockout1", "user@e2elockout1.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Set counter to 9 via DB (avoids consuming rate limit tokens)
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET failed_login_attempts = 9, locked_until = NULL WHERE id = ?", userID)
+
+	// One more wrong password should trigger lockout (10th attempt)
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "user@e2elockout1.com",
+		"password": "wrongpassword123",
+	})
+	_ = resp.Body.Close()
+
+	// Verify account is now locked
+	user, err := suite.userRepo.GetByID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if user.FailedLoginAttempts != 10 {
+		t.Errorf("Expected 10 failed attempts, got %d", user.FailedLoginAttempts)
+	}
+	if user.LockedUntil == nil {
+		t.Fatal("Expected account to be locked")
+	}
+}
+
+func TestE2E_AuthRateLimit_LockedAccountRejectsCorrectPassword(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2elockout2.com'")
+	userID := suite.registerAndLogin("e2elockout2", "user@e2elockout2.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Lock the account via DB
+	lockUntil := time.Now().Add(15 * time.Minute)
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET failed_login_attempts = 10, locked_until = ? WHERE id = ?", lockUntil, userID)
+
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "user@e2elockout2.com",
+		"password": "securepassword123", // Correct password
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("Expected 429 for locked account, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["error"] != "account_locked" {
+		t.Errorf("Expected error 'account_locked', got '%v'", body["error"])
+	}
+}
+
+func TestE2E_AuthRateLimit_LoginSucceedsAfterLockExpires(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2elockout3.com'")
+	userID := suite.registerAndLogin("e2elockout3", "user@e2elockout3.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Set lock to the past via DB
+	lockPast := time.Now().Add(-1 * time.Minute)
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET failed_login_attempts = 10, locked_until = ? WHERE id = ?", lockPast, userID)
+
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "user@e2elockout3.com",
+		"password": "securepassword123",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected 200 after lock expired, got %d", resp.StatusCode)
+	}
+
+	// Verify counter was reset
+	user, err := suite.userRepo.GetByID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if user.FailedLoginAttempts != 0 {
+		t.Errorf("Expected FailedLoginAttempts=0 after successful login, got %d", user.FailedLoginAttempts)
+	}
+}
+
+func TestE2E_AuthRateLimit_AccountLockoutAuditLog(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	// Create user
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2eaudit.com'")
+	userID := suite.registerAndLogin("e2eaudit", "user@e2eaudit.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM audit_log WHERE user_id = ?", userID)
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Set attempts to 9, then fail once more to trigger lockout
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET failed_login_attempts = 9, locked_until = NULL WHERE id = ?", userID)
+	_, _ = suite.db.ExecContext(context.Background(),
+		"DELETE FROM audit_log WHERE user_id = ? AND action = ?", userID, models.AuditActionAccountLocked)
+
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "user@e2eaudit.com",
+		"password": "wrongpassword123",
+	})
+	_ = resp.Body.Close()
+
+	// Verify audit log entry exists
+	var auditCount int
+	err := suite.db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM audit_log WHERE user_id = ? AND action = ?",
+		userID, models.AuditActionAccountLocked,
+	).Scan(&auditCount)
+	if err != nil {
+		t.Fatalf("Failed to query audit log: %v", err)
+	}
+	if auditCount == 0 {
+		t.Error("Expected audit log entry for account_locked action")
+	}
+}
+
+func TestE2E_AuthRateLimit_SuccessfulLoginResetsCounter(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2ereset.com'")
+	userID := suite.registerAndLogin("e2ereset", "user@e2ereset.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Set some failed attempts (below lockout threshold)
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET failed_login_attempts = 5, locked_until = NULL WHERE id = ?", userID)
+
+	// Login with correct password
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "user@e2ereset.com",
+		"password": "securepassword123",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected 200, got %d", resp.StatusCode)
+	}
+
+	// Verify counter was reset
+	user, err := suite.userRepo.GetByID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if user.FailedLoginAttempts != 0 {
+		t.Errorf("Expected FailedLoginAttempts=0, got %d", user.FailedLoginAttempts)
+	}
+}
+
+func TestE2E_AuthRateLimit_LockoutViaUsername(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2eusername.com'")
+	userID := suite.registerAndLogin("e2eusername", "user@e2eusername.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Set attempts to 9
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET failed_login_attempts = 9, locked_until = NULL WHERE id = ?", userID)
+
+	// Fail login using username (not email)
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "e2eusername", // Using username
+		"password": "wrongpassword123",
+	})
+	_ = resp.Body.Close()
+
+	// Verify account is locked
+	user, err := suite.userRepo.GetByID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if user.LockedUntil == nil {
+		t.Error("Expected account to be locked via username login")
+	}
+	if user.FailedLoginAttempts != 10 {
+		t.Errorf("Expected 10 failed attempts, got %d", user.FailedLoginAttempts)
+	}
+}
+
+func TestE2E_AuthRateLimit_DeletedUserNoLockout(t *testing.T) {
+	suite := SetupAuthRateLimitE2ETest(t)
+
+	_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE email LIKE '%@e2edeleted.com'")
+	userID := suite.registerAndLogin("e2edeleted", "user@e2edeleted.com", "securepassword123")
+
+	t.Cleanup(func() {
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", userID)
+	})
+
+	// Soft-delete the user
+	_, _ = suite.db.ExecContext(context.Background(),
+		"UPDATE users SET deleted_at = NOW() WHERE id = ?", userID)
+
+	// Login attempt should return 401 (not increment lockout)
+	resp := suite.postJSON("/api/v1/auth/login", map[string]string{
+		"email":    "user@e2edeleted.com",
+		"password": "securepassword123",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for deleted user, got %d", resp.StatusCode)
+	}
+
+	// Verify no lockout increment
+	user, err := suite.userRepo.GetByID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Failed to get user: %v", err)
+	}
+	if user.FailedLoginAttempts != 0 {
+		t.Errorf("Expected no lockout increment for deleted user, got %d", user.FailedLoginAttempts)
+	}
+}


### PR DESCRIPTION
## Summary
- Add per-endpoint rate limits to auth endpoints (login 10/5min, register 3/1hr, forgot-password 5/15min, reset-password 10/15min, resend-verification 3/15min)
- Lock accounts for 15 minutes after 10 consecutive failed login attempts; counter resets on successful login
- Add migration 029 for `failed_login_attempts` and `locked_until` columns on users table
- Inject rate limiter via setter to avoid changing constructor signatures

## Test plan
- [x] Database lockout unit tests (increment, lock, reset, field visibility across all query methods)
- [x] Handler unit tests (checkAuthRateLimit helper, per-endpoint rate limits, lockout flow with 10 subtests)
- [x] E2E tests (full HTTP stack: rate limit blocking, lockout accumulation, lock expiry, audit logging, deleted user handling)
- [x] `just test-unit`, `just test-db`, `just test-handlers`, `just test-e2e` all pass

Closes #9