### PR TITLE
Require auth for school/district API endpoints

### DIFF
--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -256,14 +256,6 @@ func (r *Router) authenticated(handler http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// optionalAuth wraps a handler with optional authentication middleware.
-// If a valid token is present, claims are set in context; otherwise the handler runs without claims.
-func (r *Router) optionalAuth(handler http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
-		r.jwtAuth.OptionalAuthenticate(http.HandlerFunc(handler)).ServeHTTP(w, req)
-	}
-}
-
 // authenticatedMFASetup wraps a handler with authentication for MFA setup token
 func (r *Router) authenticatedMFASetup(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {

--- a/tests/school_e2e_test.go
+++ b/tests/school_e2e_test.go
@@ -22,8 +22,12 @@ func TestE2E_SchoolSearch(t *testing.T) {
 
 	defer suite.cleanupSchools(schoolA, schoolB, schoolC)
 
+	// Register a user for authenticated requests
+	searchUserID, searchToken := suite.registerOrGetUser("e2e_school_searcher", "e2e_school_searcher@test.com", "securepassword123")
+	defer suite.cleanup(searchUserID)
+
 	t.Run("search by name", func(t *testing.T) {
-		resp := suite.request("GET", "/api/v1/schools?query=E2E", nil, "")
+		resp := suite.request("GET", "/api/v1/schools?query=E2E", nil, searchToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
@@ -39,7 +43,7 @@ func TestE2E_SchoolSearch(t *testing.T) {
 	})
 
 	t.Run("search with state filter", func(t *testing.T) {
-		resp := suite.request("GET", "/api/v1/schools?query=E2E&state=CA", nil, "")
+		resp := suite.request("GET", "/api/v1/schools?query=E2E&state=CA", nil, searchToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
@@ -57,7 +61,7 @@ func TestE2E_SchoolSearch(t *testing.T) {
 	})
 
 	t.Run("search with pagination", func(t *testing.T) {
-		resp := suite.request("GET", "/api/v1/schools?query=E2E&limit=1&page=1", nil, "")
+		resp := suite.request("GET", "/api/v1/schools?query=E2E&limit=1&page=1", nil, searchToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
@@ -77,7 +81,7 @@ func TestE2E_SchoolSearch(t *testing.T) {
 	})
 
 	t.Run("empty search returns empty array", func(t *testing.T) {
-		resp := suite.request("GET", "/api/v1/schools?query=NonexistentSchoolXYZ999", nil, "")
+		resp := suite.request("GET", "/api/v1/schools?query=NonexistentSchoolXYZ999", nil, searchToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
@@ -445,8 +449,12 @@ func TestE2E_DistrictSearchAndDetail(t *testing.T) {
 		suite.cleanupDistricts(districtID)
 	}()
 
+	// Register a user for authenticated requests
+	distViewerID, distViewerToken := suite.registerOrGetUser("e2e_dist_viewer", "e2e_dist_viewer@test.com", "securepassword123")
+	defer suite.cleanup(distViewerID)
+
 	t.Run("search districts by name", func(t *testing.T) {
-		resp := suite.request("GET", "/api/v1/school-districts?query=E2E+Test+Unified", nil, "")
+		resp := suite.request("GET", "/api/v1/school-districts?query=E2E+Test+Unified", nil, distViewerToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
@@ -462,7 +470,7 @@ func TestE2E_DistrictSearchAndDetail(t *testing.T) {
 	})
 
 	t.Run("get district details includes schools", func(t *testing.T) {
-		resp := suite.request("GET", "/api/v1/school-districts/"+districtID, nil, "")
+		resp := suite.request("GET", "/api/v1/school-districts/"+districtID, nil, distViewerToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {

--- a/tests/school_integration_test.go
+++ b/tests/school_integration_test.go
@@ -182,9 +182,13 @@ func TestIntegration_BootstrapModeTransition(t *testing.T) {
 	schoolID := suite.createSchool("Integration Bootstrap School", "CA")
 	defer suite.cleanupSchools(schoolID)
 
+	// Register a user for authenticated requests
+	viewerID, viewerToken := suite.registerOrGetUser("integ_bs_viewer", "integ_bs_viewer@test.com", "securepassword123")
+	defer suite.cleanup(viewerID)
+
 	t.Run("new school starts in bootstrap mode", func(t *testing.T) {
-		// Check the school details (public endpoint)
-		resp := suite.request("GET", "/api/v1/schools/"+schoolID, nil, "")
+		// Check the school details
+		resp := suite.request("GET", "/api/v1/schools/"+schoolID, nil, viewerToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
@@ -288,7 +292,7 @@ func TestIntegration_BootstrapModeTransition(t *testing.T) {
 		}()
 
 		// Check school details
-		resp := suite.request("GET", "/api/v1/schools/"+schoolID, nil, "")
+		resp := suite.request("GET", "/api/v1/schools/"+schoolID, nil, viewerToken)
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
## Summary
- School search (`GET /api/v1/schools`), school detail (`GET /api/v1/schools/:id`), district search (`GET /api/v1/school-districts`), and district detail (`GET /api/v1/school-districts/:id`) were publicly accessible without authentication
- This exposed member counts, verified counts, admin counts, and bootstrap mode status to unauthenticated callers — revealing which schools are active in the system and how many users they have
- All four endpoints now require JWT authentication, matching the communities pattern

## Test plan
- [x] All unit and integration tests pass
- [ ] Verify unauthenticated `curl` to `/api/v1/schools?q=test` returns 401
- [ ] Verify unauthenticated `curl` to `/api/v1/school-districts` returns 401
- [ ] Verify authenticated requests still work normally