### PR TITLE
Fix unauthenticated vouch status endpoint (security audit #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ build-errors.log
 
 # Compiled seed schools binary
 /seed-schools
+
+# Security audit (sensitive - never commit)
+SECURITY_AUDIT.md

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -172,7 +172,7 @@ func (r *Router) Setup() http.Handler {
 	r.mux.HandleFunc("/api/v1/verification/vouch", r.authenticated(r.methodHandler(http.MethodPost, r.verification.Vouch)))
 	r.mux.HandleFunc("/api/v1/verification/vouch/request", r.authenticated(r.methodHandler(http.MethodPost, r.verification.RequestVouchVerification)))
 	r.mux.HandleFunc("/api/v1/verification/vouch/pending", r.authenticated(r.methodHandler(http.MethodGet, r.verification.GetPendingVouchRequests)))
-	r.mux.HandleFunc("/api/v1/verification/vouch/status/", r.handleVouchStatus)
+	r.mux.HandleFunc("/api/v1/verification/vouch/status/", r.authenticated(r.handleVouchStatus))
 
 	// Protected routes - blocklist proposals
 	r.mux.HandleFunc("/api/v1/blocklist-proposals", r.authenticated(r.methodHandler(http.MethodGet, r.blocklistProposals.ListProposals)))

--- a/internal/handlers/verification.go
+++ b/internal/handlers/verification.go
@@ -1063,6 +1063,12 @@ func (h *VerificationHandler) Vouch(w http.ResponseWriter, r *http.Request) {
 
 // GetVouchStatus handles GET /api/v1/verification/vouch/status/:user_id
 func (h *VerificationHandler) GetVouchStatus(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.GetUserFromContext(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
 	userID := getPathParam(r, "user_id")
 	if userID == "" {
 		writeError(w, http.StatusBadRequest, "missing_parameter", "User ID required")

--- a/internal/handlers/verification_test.go
+++ b/internal/handlers/verification_test.go
@@ -1584,6 +1584,8 @@ func TestVerificationHandler_GetVouchStatus(t *testing.T) {
 		// getPathParam uses query params, so include user_id as query param
 		path := fmt.Sprintf("/api/v1/verification/vouch/status?user_id=%s&region_id=%s", targetUser.ID, region.ID)
 		req := httptest.NewRequest("GET", path, nil)
+		ctx := context.WithValue(req.Context(), middleware.UserContextKey, &middleware.Claims{UserID: voucher1.ID})
+		req = req.WithContext(ctx)
 
 		rec := httptest.NewRecorder()
 		suite.handler.GetVouchStatus(rec, req)
@@ -1615,6 +1617,8 @@ func TestVerificationHandler_GetVouchStatus(t *testing.T) {
 
 		path := fmt.Sprintf("/api/v1/verification/vouch/status?user_id=%s&region_id=%s", noVouchUser.ID, region.ID)
 		req := httptest.NewRequest("GET", path, nil)
+		ctx := context.WithValue(req.Context(), middleware.UserContextKey, &middleware.Claims{UserID: voucher1.ID})
+		req = req.WithContext(ctx)
 
 		rec := httptest.NewRecorder()
 		suite.handler.GetVouchStatus(rec, req)
@@ -1637,7 +1641,8 @@ func TestVerificationHandler_GetVouchStatus(t *testing.T) {
 	t.Run("missing user_id fails", func(t *testing.T) {
 		path := fmt.Sprintf("/api/v1/verification/vouch/status?region_id=%s", region.ID)
 		req := httptest.NewRequest("GET", path, nil)
-		// No user_id query param
+		ctx := context.WithValue(req.Context(), middleware.UserContextKey, &middleware.Claims{UserID: voucher1.ID})
+		req = req.WithContext(ctx)
 
 		rec := httptest.NewRecorder()
 		suite.handler.GetVouchStatus(rec, req)
@@ -1650,13 +1655,27 @@ func TestVerificationHandler_GetVouchStatus(t *testing.T) {
 	t.Run("missing region_id fails", func(t *testing.T) {
 		path := fmt.Sprintf("/api/v1/verification/vouch/status?user_id=%s", targetUser.ID)
 		req := httptest.NewRequest("GET", path, nil)
-		// No region_id query param
+		ctx := context.WithValue(req.Context(), middleware.UserContextKey, &middleware.Claims{UserID: voucher1.ID})
+		req = req.WithContext(ctx)
 
 		rec := httptest.NewRecorder()
 		suite.handler.GetVouchStatus(rec, req)
 
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("Expected status 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		path := fmt.Sprintf("/api/v1/verification/vouch/status?user_id=%s&region_id=%s", targetUser.ID, region.ID)
+		req := httptest.NewRequest("GET", path, nil)
+		// No claims in context
+
+		rec := httptest.NewRecorder()
+		suite.handler.GetVouchStatus(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -2866,3 +2866,46 @@ func TestE2E_MeshtasticChannelScoping(t *testing.T) {
 		}
 	})
 }
+
+func TestE2E_VouchStatusAuthRequired(t *testing.T) {
+	suite := SetupE2ETest(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	fakeUserID := "00000000-0000-0000-0000-000000000000"
+	fakeRegionID := "00000000-0000-0000-0000-000000000001"
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		resp := suite.request("GET", fmt.Sprintf("/api/v1/verification/vouch/status/%s?region_id=%s", fakeUserID, fakeRegionID), nil, "")
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid token returns 401", func(t *testing.T) {
+		resp := suite.request("GET", fmt.Sprintf("/api/v1/verification/vouch/status/%s?region_id=%s", fakeUserID, fakeRegionID), nil, "invalid.token.here")
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("authenticated request succeeds", func(t *testing.T) {
+		email := fmt.Sprintf("vouch_status_auth_%s@test.com", suffix)
+		userID, token := suite.registerOrGetUser(
+			fmt.Sprintf("vs_auth_%s", suffix),
+			email,
+			"securepassword123",
+		)
+		defer suite.cleanup(userID)
+
+		resp := suite.request("GET", fmt.Sprintf("/api/v1/verification/vouch/status/%s?region_id=%s", userID, fakeRegionID), nil, token)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Wrap `/api/v1/verification/vouch/status/` route with `r.authenticated()` to require JWT auth (was the only verification route missing it)
- Add defense-in-depth claims-nil check in `GetVouchStatus` handler, matching the pattern in `SchoolHandler.GetVouchStatus`
- Add E2E tests verifying 401 for unauthenticated/invalid-token requests and 200 for authenticated requests
- Add unit test for the claims-nil guard
- Add `SECURITY_AUDIT.md` to `.gitignore`

## Test plan
- [x] All unit tests pass (`just test`)
- [x] All E2E tests pass (run twice to confirm TestMain cleanup)
- [x] New `TestE2E_VouchStatusAuthRequired` covers unauthenticated, invalid token, and authenticated cases
- [x] New unit test subcase covers handler-level claims-nil defense-in-depth
- [x] Frontend already sends auth tokens via `static/js/api/verification.js:135`, so no UI changes needed