### PR TITLE
Fix signal group list missing region membership check (security audit #3)

### DIFF
--- a/internal/handlers/signal_groups.go
+++ b/internal/handlers/signal_groups.go
@@ -199,6 +199,18 @@ func (h *SignalGroupHandler) List(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if regionID != "" {
+		// Verify the caller is a member of the requested region (superusers bypass)
+		if !claims.IsSuperuser {
+			isMember, memberErr := h.regionRepo.IsUserInRegion(r.Context(), claims.UserID, regionID)
+			if memberErr != nil {
+				writeServerError(w, r, memberErr, "Failed to check region access", "signal_group", "check_region_access")
+				return
+			}
+			if !isMember {
+				writeError(w, http.StatusForbidden, "forbidden", "You do not have access to this region")
+				return
+			}
+		}
 		groups, err = h.groupRepo.ListByRegion(r.Context(), regionID)
 	} else {
 		groups, err = h.groupRepo.ListByUser(r.Context(), claims.UserID)

--- a/internal/handlers/signal_groups_test.go
+++ b/internal/handlers/signal_groups_test.go
@@ -289,6 +289,9 @@ func TestSignalGroupHandler_List(t *testing.T) {
 	unverifiedUser := suite.createTestUser("sg_unverified", models.TierUnverified)
 	region := suite.createTestRegion("List Test Region")
 
+	// Add verified user to region so they pass membership check
+	suite.addUserToRegion(verifiedUser.ID, region.ID, false)
+
 	// Create a signal group
 	group := &models.SignalGroup{
 		RegionID:  &region.ID,
@@ -380,6 +383,59 @@ func TestSignalGroupHandler_List(t *testing.T) {
 
 		if rec.Code != http.StatusUnauthorized {
 			t.Errorf("Expected status 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("non-member verified user gets 403", func(t *testing.T) {
+		nonMember := suite.createTestUser("sg_nonmember", models.TierVouched)
+		defer suite.cleanup([]string{nonMember.ID}, nil, nil)
+
+		req := httptest.NewRequest("GET", "/api/v1/signal-groups?region_id="+region.ID, nil)
+
+		claims := &middleware.Claims{
+			UserID:           nonMember.ID,
+			Email:            nonMember.Email,
+			VerificationTier: nonMember.VerificationTier,
+		}
+		ctx := middleware.ContextWithUser(req.Context(), claims)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		suite.handler.List(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("superuser can list any region", func(t *testing.T) {
+		superuser := suite.createTestUser("sg_superuser_list", models.TierPostcard)
+		defer suite.cleanup([]string{superuser.ID}, nil, nil)
+		// Note: superuser is NOT added to region
+
+		req := httptest.NewRequest("GET", "/api/v1/signal-groups?region_id="+region.ID, nil)
+
+		claims := &middleware.Claims{
+			UserID:           superuser.ID,
+			Email:            superuser.Email,
+			VerificationTier: superuser.VerificationTier,
+			IsSuperuser:      true,
+		}
+		ctx := middleware.ContextWithUser(req.Context(), claims)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		suite.handler.List(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var body models.SignalGroupListResponse
+		_ = json.NewDecoder(rec.Body).Decode(&body)
+
+		if len(body.Groups) == 0 {
+			t.Error("Expected at least one group in response")
 		}
 	})
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1342,6 +1342,105 @@ func TestE2E_SignalGroupsEmptyResponse(t *testing.T) {
 	})
 }
 
+func TestE2E_SignalGroupRegionAccessControl(t *testing.T) {
+	suite := SetupE2ETest(t)
+	ctx := context.Background()
+
+	// Register user A and make vouch-verified
+	userAID := suite.registerOrGetUserID("sgaccess_a", "sgaccess_a@test.com", "securepassword123")
+	suite.disableMFA(userAID)
+	suite.makeUserVouchVerified(userAID)
+
+	// Login user A to get token with vouch-verified claims
+	respA := suite.request("POST", "/api/v1/auth/login", map[string]string{
+		"email": "sgaccess_a@test.com", "password": "securepassword123",
+	}, "")
+	var loginA models.LoginResponse
+	_ = json.NewDecoder(respA.Body).Decode(&loginA)
+	_ = respA.Body.Close()
+	tokenA := loginA.Token
+
+	// Register user B and make superuser (to create regions easily)
+	userBID := suite.registerOrGetUserID("sgaccess_b", "sgaccess_b@test.com", "securepassword123")
+	suite.disableMFA(userBID)
+	_, _ = suite.db.ExecContext(ctx, "UPDATE users SET verification_tier = 2, postcard_verified = TRUE, vouch_verified = TRUE, is_superuser = TRUE WHERE id = ?", userBID)
+
+	respB := suite.request("POST", "/api/v1/auth/login", map[string]string{
+		"email": "sgaccess_b@test.com", "password": "securepassword123",
+	}, "")
+	var loginB models.LoginResponse
+	_ = json.NewDecoder(respB.Body).Decode(&loginB)
+	_ = respB.Body.Close()
+	tokenB := loginB.Token
+
+	// Create two separate regions
+	createRespA := suite.request("POST", "/api/v1/communities", map[string]interface{}{
+		"name": "Access Control Region A",
+		"type": "city",
+		"geometry": map[string]interface{}{
+			"type":        "Polygon",
+			"coordinates": [][][]float64{{{-96.6, 27.4}, {-96.4, 27.4}, {-96.4, 27.5}, {-96.6, 27.5}, {-96.6, 27.4}}},
+		},
+	}, tokenB)
+	var bodyA map[string]string
+	_ = json.NewDecoder(createRespA.Body).Decode(&bodyA)
+	_ = createRespA.Body.Close()
+	regionAID := bodyA["region_id"]
+
+	createRespB := suite.request("POST", "/api/v1/communities", map[string]interface{}{
+		"name": "Access Control Region B",
+		"type": "city",
+		"geometry": map[string]interface{}{
+			"type":        "Polygon",
+			"coordinates": [][][]float64{{{-95.6, 26.4}, {-95.4, 26.4}, {-95.4, 26.5}, {-95.6, 26.5}, {-95.6, 26.4}}},
+		},
+	}, tokenB)
+	var bodyB map[string]string
+	_ = json.NewDecoder(createRespB.Body).Decode(&bodyB)
+	_ = createRespB.Body.Close()
+	regionBID := bodyB["region_id"]
+
+	// Add user A to region A only
+	_, _ = suite.db.ExecContext(ctx, "INSERT INTO user_regions (id, user_id, region_id, is_admin, verified_at) VALUES (UUID(), ?, ?, FALSE, NOW()) ON DUPLICATE KEY UPDATE is_admin = FALSE", userAID, regionAID)
+
+	// Create a signal group in region B
+	createGroupResp := suite.request("POST", "/api/v1/signal-groups", map[string]interface{}{
+		"region_id":         regionBID,
+		"name":              "Region B Group",
+		"encrypted_payload": "dGVzdC1lbmNyeXB0ZWQtcGF5bG9hZA==",
+		"encryption_iv":     "dGVzdC1pdi0xMjM=",
+		"wrapped_keys":      []map[string]string{{"user_id": userBID, "wrapped_dek": "dGVzdC13cmFwcGVkLWRlaw=="}},
+	}, tokenB)
+	_ = createGroupResp.Body.Close()
+
+	defer func() {
+		suite.cleanupSignalGroupSecrets(regionAID)
+		suite.cleanupSignalGroupSecrets(regionBID)
+		_, _ = suite.db.ExecContext(ctx, "DELETE FROM signal_groups WHERE region_id IN (?, ?)", regionAID, regionBID)
+		_, _ = suite.db.ExecContext(ctx, "DELETE FROM user_regions WHERE region_id IN (?, ?)", regionAID, regionBID)
+		_, _ = suite.db.ExecContext(ctx, "DELETE FROM geographic_regions WHERE id IN (?, ?)", regionAID, regionBID)
+		suite.cleanup(userAID, userBID)
+	}()
+
+	t.Run("user cannot list signal groups for non-member region", func(t *testing.T) {
+		resp := suite.request("GET", "/api/v1/signal-groups?region_id="+regionBID, nil, tokenA)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("user can list signal groups for own region", func(t *testing.T) {
+		resp := suite.request("GET", "/api/v1/signal-groups?region_id="+regionAID, nil, tokenA)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+	})
+}
+
 func TestE2E_AdminHierarchyPropagation(t *testing.T) {
 	suite := SetupE2ETest(t)
 


### PR DESCRIPTION
## Summary

- The `GET /api/v1/signal-groups?region_id=<id>` endpoint checked that the caller was verified (vouch or postcard tier) but did **not** verify they were a member of the requested region. Any verified user could list signal group names, descriptions, and encrypted payloads for any region by passing an arbitrary `region_id`.
- Added `IsUserInRegion` membership check before `ListByRegion` call, with superuser bypass
- Updated existing unit test to include region membership, added non-member 403 and superuser bypass test cases
- Added cross-region E2E test (`TestE2E_SignalGroupRegionAccessControl`)

## Test plan

- [x] Existing "verified user can list signal groups" test updated to add user to region — passes
- [x] New "non-member verified user gets 403" unit test — passes
- [x] New "superuser can list any region" unit test — passes
- [x] New E2E test: user A in region A gets 403 for region B, 200 for region A
- [x] Full test suite passes twice (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)