### PR TITLE
Fix school vouch missing vouchee membership validation (security audit #4)

### DIFF
--- a/internal/handlers/schools.go
+++ b/internal/handlers/schools.go
@@ -374,6 +374,17 @@ func (h *SchoolHandler) Vouch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Check vouchee is a member of the school (must have called /join first)
+	voucheeMembership, err := h.schoolRepo.GetUserSchool(r.Context(), vouchedUserID, schoolID)
+	if err != nil {
+		writeServerError(w, r, err, "Failed to check vouchee membership", "school", "check_vouchee_membership")
+		return
+	}
+	if voucheeMembership == nil {
+		writeError(w, http.StatusBadRequest, "not_member", "This user has not joined this school yet")
+		return
+	}
+
 	// Check if vouchee is blocked
 	isBlocked, err := h.schoolRepo.IsUserBlockedInSchool(r.Context(), vouchedUserID, schoolID)
 	if err != nil {

--- a/internal/handlers/schools_test.go
+++ b/internal/handlers/schools_test.go
@@ -635,6 +635,27 @@ func TestSchoolHandler_Vouch(t *testing.T) {
 		}
 	})
 
+	t.Run("vouch for non-member returns error", func(t *testing.T) {
+		nonMemberTarget := suite.createTestUser("school_nonmember_target", models.TierUnverified)
+		defer suite.cleanup([]string{nonMemberTarget.ID}, nil, nil)
+		// Note: nonMemberTarget is NOT added to the school
+
+		claims := &middleware.Claims{
+			UserID:           voucherUser.ID,
+			Email:            voucherUser.Email,
+			VerificationTier: voucherUser.VerificationTier,
+		}
+		requestBody := models.SchoolVouchRequest{
+			UserIdentifier: nonMemberTarget.Email,
+		}
+		req, rec := suite.authenticatedRequest("POST", "/api/v1/schools/"+school.ID+"/vouch?id="+school.ID, requestBody, claims)
+		suite.handler.Vouch(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
 	t.Run("monthly vouch limit check", func(t *testing.T) {
 		// Create 10 additional users and vouch for each to exhaust the monthly limit
 		limitVoucherUser := suite.createTestUser("school_limit_voucher", models.TierPostcard)


### PR DESCRIPTION
## Summary

- The school `Vouch` handler validated the voucher was a school member but never checked whether the vouchee had joined the school
- In bootstrap mode, colluding vouchers could create vouch records for a user who never called `/join`, leading to phantom vouches and misleading 201 success responses
- Added `GetUserSchool` check for the vouchee before the block check — non-members get 400 "This user has not joined this school yet"

## Test plan

- [x] New "vouch for non-member returns error" unit test — returns 400
- [x] Existing vouch tests still pass (vouchee is added to school in setup)
- [x] Full test suite passes twice (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)