### PR TITLE
Reject votes on expired membership requests (security audit #5)

### DIFF
--- a/internal/handlers/membership.go
+++ b/internal/handlers/membership.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/opencrr/communityrapidresponse.net/internal/database"
 	"github.com/opencrr/communityrapidresponse.net/internal/middleware"
@@ -427,6 +428,9 @@ func (h *MembershipHandler) VoteOnRequest(w http.ResponseWriter, r *http.Request
 			if lockedRequest.Status != models.MembershipRequestStatusPending {
 				return database.ErrProposalClosed
 			}
+			if time.Now().After(lockedRequest.ExpiresAt) {
+				return database.ErrProposalClosed
+			}
 			hasVoted, txErr := h.membershipRepo.HasVotedTx(r.Context(), tx, requestID, claims.UserID)
 			if txErr != nil {
 				return txErr
@@ -461,6 +465,8 @@ func (h *MembershipHandler) VoteOnRequest(w http.ResponseWriter, r *http.Request
 		})
 	} else {
 		if request.Status != models.MembershipRequestStatusPending {
+			err = database.ErrProposalClosed
+		} else if time.Now().After(request.ExpiresAt) {
 			err = database.ErrProposalClosed
 		} else {
 			hasVoted, checkErr := h.membershipRepo.HasVoted(r.Context(), requestID, claims.UserID)

--- a/internal/handlers/membership_test.go
+++ b/internal/handlers/membership_test.go
@@ -1217,6 +1217,54 @@ func TestMembershipHandler_VoteOnRequest_EdgeCases(t *testing.T) {
 		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM sub_region_membership_requests WHERE id = ?", membershipRequest.ID)
 	})
 
+	t.Run("voting on expired request returns conflict", func(t *testing.T) {
+		membershipRequest := &models.SubRegionMembershipRequest{
+			UserID:         requester.ID,
+			RegionID:       subRegion.ID,
+			ParentRegionID: parentRegion.ID,
+			RequestType:    models.MembershipRequestTypeRequest,
+			InitiatedBy:    requester.ID,
+		}
+		if err := suite.membershipRepo.Create(context.Background(), membershipRequest); err != nil {
+			t.Fatalf("Failed to create test membership request: %v", err)
+		}
+
+		// Set expires_at to the past (status stays 'pending' to simulate the race window)
+		_, _ = suite.db.ExecContext(context.Background(),
+			"UPDATE sub_region_membership_requests SET expires_at = DATE_SUB(NOW(), INTERVAL 1 HOUR) WHERE id = ?",
+			membershipRequest.ID)
+
+		body := map[string]bool{"vote": true}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/membership-requests/"+membershipRequest.ID+"/vote", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		q := req.URL.Query()
+		q.Set("id", membershipRequest.ID)
+		req.URL.RawQuery = q.Encode()
+
+		claims := &middleware.Claims{
+			UserID:           admin1.ID,
+			Email:            admin1.Email,
+			VerificationTier: admin1.VerificationTier,
+			PostcardVerified: admin1.PostcardVerified,
+			VouchVerified:    admin1.VouchVerified,
+		}
+		ctx := middleware.ContextWithUser(req.Context(), claims)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		suite.handler.VoteOnRequest(rec, req)
+
+		if rec.Code != http.StatusConflict {
+			t.Errorf("Expected status 409, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		// Cleanup
+		_, _ = suite.db.ExecContext(context.Background(), "DELETE FROM sub_region_membership_requests WHERE id = ?", membershipRequest.ID)
+	})
+
 	t.Run("multiple approvals trigger membership grant", func(t *testing.T) {
 		membershipRequest := &models.SubRegionMembershipRequest{
 			UserID:         requester.ID,


### PR DESCRIPTION
## Summary

- `VoteOnRequest` checked `status='pending'` but not whether `expires_at` had passed
- Between expiration and the background cleanup worker, an admin could approve an expired membership request
- Added `time.Now().After(ExpiresAt)` check in both the transaction path (against the locked row) and the non-tx fallback path, returning the existing `ErrProposalClosed` error

## Test plan

- [x] New "voting on expired request returns conflict" unit test — creates request, sets `expires_at` to 1 hour ago, verifies 409
- [x] Existing vote tests still pass (non-expired requests work as before)
- [x] Full test suite passes twice (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)