### PR TITLE
Enforce 128-character maximum password length (security audit #8)

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -167,6 +167,11 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.Password) > 128 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must not exceed 128 characters")
+		return
+	}
+
 	// Check for '+' alias in email (reject outright)
 	if services.ContainsEmailAlias(req.Email) {
 		writeError(w, http.StatusBadRequest, "validation_error", "Email aliases with '+' are not allowed")
@@ -673,6 +678,11 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.NewPassword) > 128 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must not exceed 128 characters")
+		return
+	}
+
 	// Get user to verify current password
 	user, err := h.userRepo.GetByID(r.Context(), claims.UserID)
 	if err != nil {
@@ -848,6 +858,11 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 
 	if len(req.Password) < 12 {
 		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 12 characters")
+		return
+	}
+
+	if len(req.Password) > 128 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must not exceed 128 characters")
 		return
 	}
 

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -133,6 +134,25 @@ func TestAuthHandler_Register(t *testing.T) {
 			"username": "shortpass",
 			"email":    "short@registertest.com",
 			"password": "short",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		handler.Register(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects too long password", func(t *testing.T) {
+		body := map[string]string{
+			"username": "longpass",
+			"email":    "long@registertest.com",
+			"password": strings.Repeat("a", 129),
 		}
 		bodyBytes, _ := json.Marshal(body)
 
@@ -684,6 +704,25 @@ func TestAuthHandler_ChangePassword(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects too long new password", func(t *testing.T) {
+		body := map[string]string{
+			"current_password": "newpassword12345",
+			"new_password":     strings.Repeat("a", 129),
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/change-password", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginResp.Token)
+		rec := httptest.NewRecorder()
+
+		jwtAuth.Authenticate(http.HandlerFunc(handler.ChangePassword)).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", rec.Code)
+		}
+	})
+
 	t.Run("rejects unauthenticated request", func(t *testing.T) {
 		body := map[string]string{
 			"current_password": "newpassword12345",
@@ -886,6 +925,24 @@ func TestAuthHandler_ResetPassword(t *testing.T) {
 		body := map[string]string{
 			"token":    rawToken,
 			"password": "short",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest("POST", "/api/v1/auth/reset-password", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		handler.ResetPassword(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects too long password", func(t *testing.T) {
+		body := map[string]string{
+			"token":    "long_password_reset_token",
+			"password": strings.Repeat("a", 129),
 		}
 		bodyBytes, _ := json.Marshal(body)
 


### PR DESCRIPTION
## Summary
- Adds 128-character maximum password length check in Register, ChangePassword, and ResetPassword handlers
- Returns 400 with "Password must not exceed 128 characters" when exceeded
- Go's bcrypt truncates at 72 bytes silently — this prevents wasted CPU and avoids user confusion about effective password length

## Test plan
- [x] Unit tests added for all three endpoints (129-char password → 400)
- [ ] CI passes
- [ ] Verify 128-char password still accepted, 129-char rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)