### PR TITLE
Fix account enumeration via registration (SA-9)

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -210,16 +210,10 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.userRepo.Create(r.Context(), user); err != nil {
-		if errors.Is(err, database.ErrUserAlreadyExists) {
-			writeError(w, http.StatusConflict, "user_exists", "Username already taken")
-			return
-		}
-		if errors.Is(err, database.ErrEmailAlreadyExists) {
-			writeError(w, http.StatusConflict, "email_exists", "Email already registered")
-			return
-		}
-		if errors.Is(err, database.ErrNormalizedEmailAlreadyExists) {
-			writeError(w, http.StatusConflict, "email_exists", "An account with this email already exists")
+		if errors.Is(err, database.ErrUserAlreadyExists) ||
+			errors.Is(err, database.ErrEmailAlreadyExists) ||
+			errors.Is(err, database.ErrNormalizedEmailAlreadyExists) {
+			writeError(w, http.StatusConflict, "account_exists", "An account with these credentials already exists")
 			return
 		}
 		writeServerError(w, r, err, "Failed to create user", "auth", "register")

--- a/tests/email_verification_test.go
+++ b/tests/email_verification_test.go
@@ -436,8 +436,8 @@ func TestE2E_Registration_RejectsDuplicateNormalizedEmail(t *testing.T) {
 				if resp2.StatusCode != http.StatusConflict {
 					t.Errorf("Expected status 409 (conflict), got %d", resp2.StatusCode)
 				}
-				if body2["error"] != "email_exists" {
-					t.Errorf("Expected error 'email_exists', got '%s'", body2["error"])
+				if body2["error"] != "account_exists" {
+					t.Errorf("Expected error 'account_exists', got '%s'", body2["error"])
 				}
 				suite.cleanup(userID1)
 			} else {

--- a/tests/registration_e2e_test.go
+++ b/tests/registration_e2e_test.go
@@ -345,8 +345,8 @@ func TestE2E_Registration_DuplicateUsername(t *testing.T) {
 		var body map[string]interface{}
 		_ = json.NewDecoder(resp.Body).Decode(&body)
 
-		if body["error"] != "user_exists" {
-			t.Errorf("Expected error 'user_exists', got '%v'", body["error"])
+		if body["error"] != "account_exists" {
+			t.Errorf("Expected error 'account_exists', got '%v'", body["error"])
 		}
 	})
 }
@@ -381,8 +381,8 @@ func TestE2E_Registration_DuplicateEmail(t *testing.T) {
 		var body map[string]interface{}
 		_ = json.NewDecoder(resp.Body).Decode(&body)
 
-		if body["error"] != "email_exists" {
-			t.Errorf("Expected error 'email_exists', got '%v'", body["error"])
+		if body["error"] != "account_exists" {
+			t.Errorf("Expected error 'account_exists', got '%v'", body["error"])
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Merge distinct `user_exists`/`email_exists` error codes in the Register handler into a single generic `account_exists` response, preventing attackers from enumerating valid usernames and emails via the API
- Update E2E test assertions to match the new error code

## Test plan
- [ ] `go vet ./...` passes
- [ ] Handler unit tests pass
- [ ] Registration E2E tests pass with new `account_exists` error code
- [ ] Email verification E2E tests pass with new `account_exists` error code