### PR TITLE
Narrow CSRF exemption scope to exact-path matching (SA-10)

### DIFF
--- a/internal/middleware/csrf.go
+++ b/internal/middleware/csrf.go
@@ -20,13 +20,20 @@ const csrfHeaderName = "X-CSRF-Token"
 // Matches the JWT token expiration so the cookie persists for returning users.
 const csrfCookieMaxAge = 86400
 
-// csrfExemptPrefixes are path prefixes exempt from CSRF validation.
-// These are unauthenticated/pre-auth endpoints where no existing session can
-// be exploited. Note: /api/v1/auth/ includes change-password, which is
-// acceptable because it requires a valid JWT and the current password.
-var csrfExemptPrefixes = []string{
-	"/api/v1/auth/",
-	"/api/v1/mfa/",
+// csrfExemptPaths are exact paths exempt from CSRF validation.
+// Only unauthenticated/pre-auth endpoints are listed here. Authenticated
+// endpoints like change-password and resend-verification require CSRF
+// as defense-in-depth.
+var csrfExemptPaths = map[string]bool{
+	"/api/v1/auth/register":        true,
+	"/api/v1/auth/login":           true,
+	"/api/v1/auth/logout":          true,
+	"/api/v1/auth/forgot-password": true,
+	"/api/v1/auth/reset-password":  true,
+	"/api/v1/auth/verify-email":    true,
+	"/api/v1/mfa/setup":            true,
+	"/api/v1/mfa/setup/complete":   true,
+	"/api/v1/mfa/verify":           true,
 }
 
 // deriveCSRFSecret derives a dedicated CSRF signing key from the application
@@ -56,12 +63,10 @@ func CSRFProtection(secret string, secureCookies bool) func(http.Handler) http.H
 			}
 
 			// Unsafe methods: check exempt paths first
-			for _, prefix := range csrfExemptPrefixes {
-				if strings.HasPrefix(r.URL.Path, prefix) {
-					ensureCSRFCookie(w, r, csrfSecret, secureCookies)
-					next.ServeHTTP(w, r)
-					return
-				}
+			if csrfExemptPaths[r.URL.Path] {
+				ensureCSRFCookie(w, r, csrfSecret, secureCookies)
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			// Validate CSRF token

--- a/internal/middleware/csrf_test.go
+++ b/internal/middleware/csrf_test.go
@@ -184,7 +184,6 @@ func TestCSRFProtection_ExemptPathsBypass(t *testing.T) {
 		"/api/v1/auth/logout",
 		"/api/v1/auth/forgot-password",
 		"/api/v1/auth/reset-password",
-		"/api/v1/auth/resend-verification",
 		"/api/v1/auth/verify-email",
 		"/api/v1/mfa/setup",
 		"/api/v1/mfa/setup/complete",
@@ -213,6 +212,8 @@ func TestCSRFProtection_NonExemptPathRequiresToken(t *testing.T) {
 		"/api/v1/signal-groups",
 		"/api/v1/verification/postcard/request",
 		"/api/v1/deletion-proposals",
+		"/api/v1/auth/change-password",
+		"/api/v1/auth/resend-verification",
 	}
 
 	for _, path := range nonExemptPaths {

--- a/tests/csrf_e2e_test.go
+++ b/tests/csrf_e2e_test.go
@@ -377,7 +377,6 @@ func TestCSRFIntegration_ExemptAuthEndpoints(t *testing.T) {
 			"token":    "invalidtoken",
 			"password": "newpassword12345",
 		}},
-		{"/api/v1/auth/resend-verification", nil},
 	}
 
 	for _, tc := range exemptPaths {
@@ -965,7 +964,7 @@ func TestCSRF_E2E_TokenReusableAcrossMultipleRequests(t *testing.T) {
 	}
 }
 
-func TestCSRF_E2E_ChangePasswordExemptAsAuthEndpoint(t *testing.T) {
+func TestCSRF_E2E_ChangePasswordRequiresCSRF(t *testing.T) {
 	suite := SetupCSRFTest(t)
 
 	client := suite.newCookieClient()
@@ -980,20 +979,39 @@ func TestCSRF_E2E_ChangePasswordExemptAsAuthEndpoint(t *testing.T) {
 		t.Fatal("expected JWT token after login")
 	}
 
-	// Change password WITHOUT CSRF — should succeed (exempt under /api/v1/auth/ prefix)
+	// GET to acquire CSRF cookie
+	resp0 := suite.doRequest(client, "GET", "/api/v1/health", nil, "")
+	_ = resp0.Body.Close()
+
+	// Change password WITHOUT CSRF header — should be rejected (no longer exempt)
 	resp := suite.doRequest(client, "POST", "/api/v1/auth/change-password", map[string]string{
 		"current_password": password,
 		"new_password":     "newsecurepassword456",
 	}, jwtToken)
 	defer func() { _ = resp.Body.Close() }()
 
-	// /api/v1/auth/change-password is under the /api/v1/auth/ exempt prefix,
-	// so it must NOT be blocked by CSRF validation.
-	if resp.StatusCode == http.StatusForbidden {
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("change-password without CSRF: expected 403, got %d", resp.StatusCode)
+	} else {
 		var body map[string]string
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		if body["error"] == "csrf_validation_failed" {
-			t.Error("/api/v1/auth/change-password should be exempt from CSRF (under /api/v1/auth/ prefix)")
+		if body["error"] != "csrf_validation_failed" {
+			t.Errorf("expected csrf_validation_failed error, got %q", body["error"])
+		}
+	}
+
+	// Change password WITH valid CSRF — should pass CSRF check
+	resp2 := suite.doRequestWithCSRF(client, "POST", "/api/v1/auth/change-password", map[string]string{
+		"current_password": password,
+		"new_password":     "newsecurepassword456",
+	}, jwtToken)
+	defer func() { _ = resp2.Body.Close() }()
+
+	if resp2.StatusCode == http.StatusForbidden {
+		var body2 map[string]string
+		_ = json.NewDecoder(resp2.Body).Decode(&body2)
+		if body2["error"] == "csrf_validation_failed" {
+			t.Error("change-password with valid CSRF should not be rejected")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replaced broad `/api/v1/auth/` and `/api/v1/mfa/` prefix-based CSRF exemptions with an exact-path allowlist of 9 unauthenticated/pre-auth endpoints
- `POST /api/v1/auth/change-password` and `POST /api/v1/auth/resend-verification` now require CSRF validation as defense-in-depth
- Frontend already sends CSRF tokens on all state-changing requests, so no client changes needed

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./internal/middleware/... -run TestCSRF` — all pass
- [x] `go test ./tests/... -run TestCSRF` — compiles, skipped without DB (CI will run)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)