### PR TITLE
Make password reset atomic with single DB transaction (SA-20)

### DIFF
--- a/internal/database/password_reset.go
+++ b/internal/database/password_reset.go
@@ -159,6 +159,24 @@ func (r *PasswordResetRepository) CreateTx(ctx context.Context, tx *sql.Tx, user
 	return token, nil
 }
 
+// MarkUsedTx sets the used_at timestamp for a token within a transaction
+func (r *PasswordResetRepository) MarkUsedTx(ctx context.Context, tx *sql.Tx, tokenID string) error {
+	query := `UPDATE password_reset_tokens SET used_at = ? WHERE id = ?`
+	_, err := tx.ExecContext(ctx, query, time.Now().UTC(), tokenID)
+	return err
+}
+
+// InvalidateForUserTx marks all unused tokens for a user as used within a transaction
+func (r *PasswordResetRepository) InvalidateForUserTx(ctx context.Context, tx *sql.Tx, userID string) error {
+	query := `
+		UPDATE password_reset_tokens
+		SET used_at = ?
+		WHERE user_id = ? AND used_at IS NULL
+	`
+	_, err := tx.ExecContext(ctx, query, time.Now().UTC(), userID)
+	return err
+}
+
 // CleanupExpired deletes tokens that have been expired for more than 24 hours
 func (r *PasswordResetRepository) CleanupExpired(ctx context.Context) (int64, error) {
 	query := `

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -936,6 +936,30 @@ func (r *UserRepository) InvalidateTokens(ctx context.Context, userID string) er
 	return err
 }
 
+// UpdatePasswordTx updates a user's password hash within a transaction
+func (r *UserRepository) UpdatePasswordTx(ctx context.Context, tx *sql.Tx, userID, newPasswordHash string) error {
+	query := `UPDATE users SET password_hash = ? WHERE id = ?`
+	result, err := tx.ExecContext(ctx, query, newPasswordHash, userID)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// InvalidateTokensTx sets the token_invalidated_at timestamp within a transaction
+func (r *UserRepository) InvalidateTokensTx(ctx context.Context, tx *sql.Tx, userID string) error {
+	query := `UPDATE users SET token_invalidated_at = NOW() WHERE id = ?`
+	_, err := tx.ExecContext(ctx, query, userID)
+	return err
+}
+
 // GetVerifiedUsersInRegion returns users who are postcard OR vouch verified in a specific region.
 // Results are paginated for memory efficiency when dealing with large regions.
 func (r *UserRepository) GetVerifiedUsersInRegion(ctx context.Context, regionID string, offset, limit int) ([]*models.User, error) {

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -906,25 +906,41 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update password
-	if err := h.userRepo.UpdatePassword(r.Context(), resetToken.UserID, string(hashedPassword)); err != nil {
-		writeServerError(w, r, err, "Failed to update password", "auth", "reset_password")
-		return
+	// Update password, invalidate tokens, and mark reset token used — all atomically
+	if h.db != nil {
+		txErr := h.db.Transaction(r.Context(), func(tx *sql.Tx) error {
+			if err := h.userRepo.UpdatePasswordTx(r.Context(), tx, resetToken.UserID, string(hashedPassword)); err != nil {
+				return err
+			}
+			if err := h.userRepo.InvalidateTokensTx(r.Context(), tx, resetToken.UserID); err != nil {
+				return err
+			}
+			if err := h.passwordResetRepo.MarkUsedTx(r.Context(), tx, resetToken.ID); err != nil {
+				return err
+			}
+			return h.passwordResetRepo.InvalidateForUserTx(r.Context(), tx, resetToken.UserID)
+		})
+		if txErr != nil {
+			writeServerError(w, r, txErr, "Failed to reset password", "auth", "reset_password")
+			return
+		}
+	} else {
+		// Non-transactional fallback (unit tests where h.db is nil)
+		if err := h.userRepo.UpdatePassword(r.Context(), resetToken.UserID, string(hashedPassword)); err != nil {
+			writeServerError(w, r, err, "Failed to update password", "auth", "reset_password")
+			return
+		}
+		if err := h.userRepo.InvalidateTokens(r.Context(), resetToken.UserID); err != nil {
+			slog.WarnContext(r.Context(), "failed to invalidate tokens after password reset", "user_id", resetToken.UserID, "error", err)
+		}
+		_ = h.passwordResetRepo.MarkUsed(r.Context(), resetToken.ID)
+		_ = h.passwordResetRepo.InvalidateForUser(r.Context(), resetToken.UserID)
 	}
 
-	// Invalidate existing tokens so old sessions are rejected
-	if err := h.userRepo.InvalidateTokens(r.Context(), resetToken.UserID); err != nil {
-		slog.WarnContext(r.Context(), "failed to invalidate tokens after password reset", "user_id", resetToken.UserID, "error", err)
-	}
+	// Evict status cache so middleware picks up the invalidated epoch immediately
 	if h.jwtAuth != nil {
 		h.jwtAuth.InvalidateUserCache(resetToken.UserID)
 	}
-
-	// Mark token as used
-	_ = h.passwordResetRepo.MarkUsed(r.Context(), resetToken.ID)
-
-	// Invalidate all other tokens for this user
-	_ = h.passwordResetRepo.InvalidateForUser(r.Context(), resetToken.UserID)
 
 	// Audit log
 	if h.auditRepo != nil {

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -957,6 +957,83 @@ func TestAuthHandler_ResetPassword(t *testing.T) {
 		}
 	})
 
+	t.Run("returns 500 when user deleted before reset (tx rollback)", func(t *testing.T) {
+		// Create a handler with db set, so the transactional path is taken
+		txHandler := NewAuthHandlerWithEmailService(
+			db, userRepo, jwtAuth, nil, "test_secret_key_at_least_32_characters_long",
+			false, false, nil, passwordResetRepo, nil, "http://localhost:3000", nil,
+		)
+
+		// Create a throwaway user and a valid token for them
+		regBody := map[string]string{
+			"username": "resetghost",
+			"email":    "ghost@resetpasstest.com",
+			"password": "securepassword123",
+		}
+		regBytes, _ := json.Marshal(regBody)
+		regReq := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewReader(regBytes))
+		regReq.Header.Set("Content-Type", "application/json")
+		regRec := httptest.NewRecorder()
+		txHandler.Register(regRec, regReq)
+
+		var ghostResp models.RegisterResponse
+		_ = json.NewDecoder(regRec.Body).Decode(&ghostResp)
+
+		rawToken := "ghost_user_reset_token_test"
+		tokenHash := fmt.Sprintf("%x", sha256Of(rawToken))
+		_, err := passwordResetRepo.Create(context.Background(), ghostResp.UserID, tokenHash, timeInFuture(1))
+		if err != nil {
+			t.Fatalf("Failed to create token: %v", err)
+		}
+
+		// Delete the user — CASCADE removes reset tokens too, but the handler
+		// does GetByTokenHash (non-tx) BEFORE the transaction. To simulate a
+		// race where the user is deleted between token lookup and password update,
+		// we disable FK checks, re-insert the orphaned token, then re-enable.
+		// Must use a single connection since FOREIGN_KEY_CHECKS is session-scoped.
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", ghostResp.UserID)
+		conn, connErr := db.Conn(context.Background())
+		if connErr != nil {
+			t.Fatalf("Failed to get DB connection: %v", connErr)
+		}
+		_, _ = conn.ExecContext(context.Background(), "SET FOREIGN_KEY_CHECKS=0")
+		_, _ = conn.ExecContext(context.Background(),
+			"INSERT INTO password_reset_tokens (id, user_id, token_hash, created_at, expires_at) VALUES (?, ?, ?, NOW(), ?)",
+			"ghost-token-id", ghostResp.UserID, tokenHash, timeInFuture(1))
+		_, _ = conn.ExecContext(context.Background(), "SET FOREIGN_KEY_CHECKS=1")
+		_ = conn.Close()
+
+		body := map[string]string{
+			"token":    rawToken,
+			"password": "securepassword123",
+		}
+		bodyBytes, _ := json.Marshal(body)
+		req := httptest.NewRequest("POST", "/api/v1/auth/reset-password", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		txHandler.ResetPassword(rec, req)
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("Expected 500 for deleted user tx rollback, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		// Verify the token was NOT consumed (tx rolled back)
+		_, lookupErr := passwordResetRepo.GetByTokenHash(context.Background(), tokenHash)
+		if lookupErr != nil {
+			t.Errorf("Expected token to still be valid after rollback, got error: %v", lookupErr)
+		}
+
+		// Cleanup orphaned token (single connection for FK checks)
+		cleanConn, _ := db.Conn(context.Background())
+		if cleanConn != nil {
+			_, _ = cleanConn.ExecContext(context.Background(), "SET FOREIGN_KEY_CHECKS=0")
+			_, _ = cleanConn.ExecContext(context.Background(), "DELETE FROM password_reset_tokens WHERE user_id = ?", ghostResp.UserID)
+			_, _ = cleanConn.ExecContext(context.Background(), "SET FOREIGN_KEY_CHECKS=1")
+			_ = cleanConn.Close()
+		}
+	})
+
 	// Cleanup
 	_, _ = db.ExecContext(context.Background(), "DELETE FROM password_reset_tokens WHERE user_id = ?", resetRegisterResp.UserID)
 	_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", resetRegisterResp.UserID)

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -3,6 +3,8 @@ package tests
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -97,8 +99,14 @@ func SetupE2ETest(t *testing.T) *E2ETestSuite {
 	mockPostgrid := mocks.NewMockPostgridService()
 	mockMapbox := mocks.NewMockMapboxService()
 
+	passwordResetRepo := database.NewPasswordResetRepository(db)
+
 	// Create handlers with mock services
-	authHandler := handlers.NewAuthHandler(userRepo, jwtAuth)
+	authHandler := handlers.NewAuthHandlerWithEmailService(
+		db, userRepo, jwtAuth, nil, jwtConfig.Secret,
+		false, true, auditRepo, passwordResetRepo, nil,
+		"http://localhost:3000", encryptionKeyRepo,
+	)
 	regionHandler := handlers.NewRegionHandler(regionRepo, mockMapbox, nil)
 	verificationHandler := handlers.NewVerificationHandler(
 		nil, verifyRepo, vouchRepo, userRepo, regionRepo,
@@ -3454,6 +3462,93 @@ func TestE2E_SessionRevocation(t *testing.T) {
 		_ = resp2.Body.Close()
 		if resp2.StatusCode != http.StatusForbidden {
 			t.Errorf("Expected 403 after superuser revocation, got %d", resp2.StatusCode)
+		}
+	})
+}
+
+func TestE2E_PasswordReset(t *testing.T) {
+	suite := SetupE2ETest(t)
+
+	originalPassword := "securepassword123"
+	newPassword := "newsecurepassword456"
+	email := fmt.Sprintf("pwreset-%d@test.com", time.Now().UnixNano())
+	username := fmt.Sprintf("pwreset%d", time.Now().UnixNano()%100000)
+
+	// Register user and get userID
+	userID := suite.registerOrGetUserID(username, email, originalPassword)
+	suite.disableMFA(userID)
+	defer suite.cleanup(userID)
+
+	// Verify login works with original password
+	loginResp := suite.request("POST", "/api/v1/auth/login", map[string]string{
+		"email": email, "password": originalPassword,
+	}, "")
+	_ = loginResp.Body.Close()
+	if loginResp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected login 200, got %d", loginResp.StatusCode)
+	}
+
+	// Create a password reset token directly in the DB
+	// (We can't go through forgot-password because email service is nil)
+	rawToken := fmt.Sprintf("%064x", time.Now().UnixNano()) // 64 hex chars
+	tokenHashBytes := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(tokenHashBytes[:])
+	tokenID := fmt.Sprintf("prt-%d", time.Now().UnixNano())
+	expiresAt := time.Now().UTC().Add(1 * time.Hour)
+
+	_, err := suite.db.ExecContext(context.Background(),
+		"INSERT INTO password_reset_tokens (id, user_id, token_hash, created_at, expires_at) VALUES (?, ?, ?, NOW(), ?)",
+		tokenID, userID, tokenHash, expiresAt)
+	if err != nil {
+		t.Fatalf("Failed to insert reset token: %v", err)
+	}
+
+	t.Run("reset password with valid token", func(t *testing.T) {
+		resp := suite.request("POST", "/api/v1/auth/reset-password", map[string]string{
+			"token": rawToken, "password": newPassword,
+		}, "")
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			var body map[string]interface{}
+			_ = json.NewDecoder(resp.Body).Decode(&body)
+			t.Fatalf("Expected 200, got %d: %v", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("login with new password succeeds", func(t *testing.T) {
+		// Small delay to let token invalidation propagate through status cache
+		time.Sleep(200 * time.Millisecond)
+
+		resp := suite.request("POST", "/api/v1/auth/login", map[string]string{
+			"email": email, "password": newPassword,
+		}, "")
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected login 200 with new password, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("login with old password fails", func(t *testing.T) {
+		resp := suite.request("POST", "/api/v1/auth/login", map[string]string{
+			"email": email, "password": originalPassword,
+		}, "")
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected login 401 with old password, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("token reuse rejected", func(t *testing.T) {
+		resp := suite.request("POST", "/api/v1/auth/reset-password", map[string]string{
+			"token": rawToken, "password": "yetanotherpassword12",
+		}, "")
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("Expected 400 for reused token, got %d", resp.StatusCode)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Wraps the 4 sequential non-transactional DB operations in `ResetPassword` (update password, invalidate session tokens, mark reset token used, invalidate all user reset tokens) in a single `h.db.Transaction()` call for all-or-nothing atomicity
- Adds `UpdatePasswordTx` and `InvalidateTokensTx` to `UserRepository`, `MarkUsedTx` and `InvalidateForUserTx` to `PasswordResetRepository`
- Preserves non-transactional fallback for unit tests (where `h.db` is nil)

## Test plan

- [x] `go vet ./...` clean
- [x] Existing `TestAuthHandler_ResetPassword` unit tests pass (exercise non-tx fallback path)
- [x] New `TestE2E_PasswordReset` covers full transactional path:
  - Reset password with valid token (200)
  - Login with new password succeeds
  - Login with old password rejected (401)
  - Token reuse rejected (400)