### PR TITLE
security: PII exposure scan and .gitignore hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,22 @@ build-errors.log
 # Compiled seed schools binary
 /seed-schools
 
-# Security audit (sensitive - never commit)
+# Security audit and scan reports (sensitive - never commit)
 SECURITY_AUDIT.md
+PII_SCAN_REPORT.md
+
+# Certificates and keys
+*.pem
+*.key
+*.crt
+*.pfx
+*.p12
+
+# Credential and secrets files
+credentials.*
+secrets.*
+
+# Data dumps and exports (may contain sensitive user data)
+*.csv
+*.xlsx
+*.xls


### PR DESCRIPTION
## Summary

- Scanned the entire repository for PII exposure across 5 categories
- Added missing sensitive file patterns to `.gitignore`
- Full scan report in PR description (not committed, as it documents security weaknesses)

## Findings Summary

| Category | Critical | High | Medium | Low | Total |
|---|---|---|---|---|---|
| hardcoded-pii | 0 | 0 | 0 | 1 | 1 |
| pii-in-logs | 0 | 2 | 1 | 1 | 4 |
| env-secret | 0 | 0 | 1 | 1 | 2 |
| unencrypted-storage | 0 | 0 | 0 | 1 | 1 |
| gitignore-gap | 0 | 0 | 2 | 0 | 2 |
| **Total** | **0** | **2** | **4** | **4** | **10** |

### High Severity
- **Finding 2** (email_smtp.go:68,116,166): Email addresses logged via slog.Info
- **Finding 3** (email_sendgrid.go:58,104): Email addresses logged via slog.Info

### Medium Severity
- **Finding 1** (templates/index.html:20): Mapbox public token - URL-restrict in dashboard
- **Finding 4** (email_mock.go:40,46): Mock service logs emails - risk if enabled in prod
- **Finding 7** (.gitignore): Missing cert/key/credential patterns - **FIXED**
- **Finding 8** (.gitignore): PII_SCAN_REPORT.md not covered - **FIXED**

### Low Severity
- **Finding 5** (mfa.go:325): UUID in error message - pseudonymous, not PII
- **Finding 6** (email_test.go): Semi-realistic test emails - prefer @example.com
- **Finding 9** (docker-compose.yml): Dev credentials - prod config rejects defaults
- **Finding 10** (user.go:36): address_hash never populated - feature gap

### Positive: No Issues Found
- Passwords: bcrypt-12 ✓ | MFA: AES-256-GCM ✓ | Reset tokens: SHA-256 ✓
- Zero-address-storage: verified ✓ | No SSN/CC/phone in schema ✓
- Production config rejects dev defaults ✓

## Test plan
- [x] .gitignore changes don't exclude legitimate project files
- [x] PII_SCAN_REPORT.md is properly gitignored
- [ ] Remediate high-severity email logging findings