### PR TITLE
fix: bump Go 1.25.9 for CVE fixes + redact PII from email service logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.25.9'
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.9-alpine AS builder
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server ./cmd/server
 
 # Development stage with hot reload
-FROM golang:1.25-alpine AS development
+FROM golang:1.25.9-alpine AS development
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencrr/communityrapidresponse.net
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/services/email.go
+++ b/internal/services/email.go
@@ -13,6 +13,18 @@ var (
 	ErrUnsupportedEmailBackend = errors.New("unsupported email backend")
 )
 
+func redactEmail(email string) string {
+	parts := strings.SplitN(email, "@", 2)
+	if len(parts) != 2 {
+		return "***"
+	}
+	local := parts[0]
+	if len(local) <= 1 {
+		return local + "***@" + parts[1]
+	}
+	return string(local[0]) + "***@" + parts[1]
+}
+
 // NewEmailService creates an email service based on the configuration.
 // It returns the appropriate backend implementation based on cfg.Backend.
 //

--- a/internal/services/email_mock.go
+++ b/internal/services/email_mock.go
@@ -37,13 +37,13 @@ func (s *MockEmailService) Backend() string {
 
 // Send logs email details instead of sending
 func (s *MockEmailService) Send(ctx context.Context, msg *EmailMessage) error {
-	slog.Info("mock email sent", "to", msg.To, "subject", msg.Subject)
+	slog.Info("mock email sent", "to", redactEmail(msg.To), "subject", msg.Subject)
 	return nil
 }
 
 // SendVerificationEmail logs the verification email details
 func (s *MockEmailService) SendVerificationEmail(ctx context.Context, toEmail, token string) error {
-	slog.Info("mock verification email sent", "to", toEmail, "subject", "Verify your email address - Community Rapid Response")
+	slog.Info("mock verification email sent", "to", redactEmail(toEmail), "subject", "Verify your email address - Community Rapid Response")
 	return nil
 }
 

--- a/internal/services/email_sendgrid.go
+++ b/internal/services/email_sendgrid.go
@@ -55,7 +55,7 @@ func (s *SendGridEmailService) Send(ctx context.Context, msg *EmailMessage) erro
 	}
 
 	if !s.enabled {
-		slog.Info("sendgrid disabled, would send email", "to", msg.To, "subject", msg.Subject)
+		slog.Info("sendgrid disabled, would send email", "to", redactEmail(msg.To), "subject", msg.Subject)
 		return nil
 	}
 
@@ -101,7 +101,7 @@ func (s *SendGridEmailService) Send(ctx context.Context, msg *EmailMessage) erro
 		return fmt.Errorf("SendGrid API error: status %d", resp.StatusCode)
 	}
 
-	slog.Info("email sent via sendgrid", "to", msg.To)
+	slog.Info("email sent via sendgrid", "to", redactEmail(msg.To))
 	return nil
 }
 

--- a/internal/services/email_smtp.go
+++ b/internal/services/email_smtp.go
@@ -65,7 +65,7 @@ func generateBoundary() string {
 // Send sends a generic email message via SMTP
 func (s *SMTPEmailService) Send(ctx context.Context, msg *EmailMessage) error {
 	if !s.enabled {
-		slog.Info("smtp disabled, would send email", "to", msg.To, "subject", msg.Subject)
+		slog.Info("smtp disabled, would send email", "to", redactEmail(msg.To), "subject", msg.Subject)
 		return nil
 	}
 
@@ -113,7 +113,7 @@ func (s *SMTPEmailService) Send(ctx context.Context, msg *EmailMessage) error {
 		return fmt.Errorf("failed to send email via SMTP: %w", err)
 	}
 
-	slog.Info("email sent via smtp", "to", msg.To)
+	slog.Info("email sent via smtp", "to", redactEmail(msg.To))
 	return nil
 }
 
@@ -163,7 +163,7 @@ func (s *SMTPEmailService) sendWithTLS(addr string, auth smtp.Auth, from, to str
 		return fmt.Errorf("failed to close email body: %w", err)
 	}
 
-	slog.Info("email sent via smtp with tls", "to", to)
+	slog.Info("email sent via smtp with tls", "to", redactEmail(to))
 	return nil
 }
 

--- a/internal/services/email_test.go
+++ b/internal/services/email_test.go
@@ -8,9 +8,9 @@ func TestNormalizeEmail_RejectsPlus(t *testing.T) {
 	testCases := []struct {
 		email string
 	}{
-		{"user+test@gmail.com"},
+		{"user+test@example.com"},
 		{"john+alias@example.com"},
-		{"test+123@yahoo.com"},
+		{"test+123@example.com"},
 	}
 
 	for _, tc := range testCases {
@@ -73,10 +73,10 @@ func TestNormalizeEmail_PreservesDotsForOtherDomains(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"j.doe@yahoo.com", "j.doe@yahoo.com"},
-		{"john.smith@outlook.com", "john.smith@outlook.com"},
-		{"user.name@example.org", "user.name@example.org"},
-		{"J.Doe@YAHOO.COM", "j.doe@yahoo.com"},
+		{"j.doe@example.com", "j.doe@example.com"},
+		{"john.smith@example.org", "john.smith@example.org"},
+		{"user.name@example.net", "user.name@example.net"},
+		{"J.Doe@example.com", "j.doe@example.com"},
 	}
 
 	for _, tc := range testCases {
@@ -115,8 +115,8 @@ func TestContainsEmailAlias(t *testing.T) {
 		email    string
 		expected bool
 	}{
-		{"user+test@gmail.com", true},
-		{"user@gmail.com", false},
+		{"user+test@example.com", true},
+		{"user@example.com", false},
 		{"john+@example.com", true},
 		{"+test@example.com", true},
 		{"noplussign@example.com", false},


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.0 to 1.25.9 to fix GO-2026-4947, GO-2026-4946, GO-2026-4870 (stdlib crypto/tls and x509 CVEs)
- Redact email addresses from slog.Info calls in SMTP, SendGrid, and mock email services
- Use @example.com in test fixtures

## Test plan
- [ ] Verify `go mod tidy` produces no diff
- [ ] Run `go test ./internal/services/` — all email tests pass
- [ ] Run `govulncheck ./...` — no findings for GO-2026-4947, GO-2026-4946, GO-2026-4870
- [ ] Grep for `"to", msg.To` or `"to", toEmail` in services — no unredacted emails remain