### PR TITLE
security: audit for common foot-guns and apply low-risk fixes

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -60,26 +60,45 @@ func Recoverer(next http.Handler) http.Handler {
 	})
 }
 
-// CORS adds CORS headers
+// CORS adds CORS headers.
+//
+// Security note: when the allowed-origins list contains "*" and a cross-origin
+// request arrives, we respond with a literal "*" origin and OMIT the
+// Access-Control-Allow-Credentials header. Browsers reject credentialed
+// requests against a wildcard origin, which prevents the classic
+// "reflect arbitrary origin + credentials=true" footgun that would otherwise
+// allow any site to make authenticated cross-origin requests.
+// For exact-match origins (the production path) we continue to echo the
+// origin back with credentials enabled.
 func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
-			// Check if origin is allowed
 			allowed := false
+			wildcard := false
 			for _, o := range allowedOrigins {
-				if o == "*" || o == origin {
+				if o == "*" {
 					allowed = true
+					wildcard = true
+					continue
+				}
+				if o == origin {
+					allowed = true
+					wildcard = false
 					break
 				}
 			}
 
 			if allowed {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
+				if wildcard {
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, X-CSRF-Token")
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
 				w.Header().Set("Access-Control-Max-Age", "86400")
 			}
 
@@ -130,6 +149,9 @@ func SecurityHeadersWithConfig(cfg *SecurityConfig) func(http.Handler) http.Hand
 			w.Header().Set("X-Frame-Options", "DENY")
 			w.Header().Set("X-XSS-Protection", "1; mode=block")
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			// Disable powerful browser APIs we never use. Narrows the blast
+			// radius of any future XSS and blocks passive fingerprinting vectors.
+			w.Header().Set("Permissions-Policy", "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()")
 
 			if cfg != nil {
 				if cfg.CSPDirectives != "" {

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -73,7 +73,7 @@ func TestCORS(t *testing.T) {
 		}
 	})
 
-	t.Run("allows wildcard origin", func(t *testing.T) {
+	t.Run("wildcard responds with literal * and no credentials", func(t *testing.T) {
 		handler := CORS([]string{"*"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -84,8 +84,27 @@ func TestCORS(t *testing.T) {
 
 		handler.ServeHTTP(rec, req)
 
-		if rec.Header().Get("Access-Control-Allow-Origin") != "https://any-origin.com" {
-			t.Error("Expected Access-Control-Allow-Origin header for wildcard")
+		if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
+			t.Errorf("Wildcard must respond with literal '*', got %q", rec.Header().Get("Access-Control-Allow-Origin"))
+		}
+		if rec.Header().Get("Access-Control-Allow-Credentials") != "" {
+			t.Error("Wildcard must not set Access-Control-Allow-Credentials (browsers reject the combination)")
+		}
+	})
+
+	t.Run("exact-match origin sets credentials", func(t *testing.T) {
+		handler := CORS([]string{"https://example.com"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Origin", "https://example.com")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Header().Get("Access-Control-Allow-Credentials") != "true" {
+			t.Error("Exact-match origin must enable credentials")
 		}
 	})
 
@@ -226,6 +245,10 @@ func TestSecurityHeaders(t *testing.T) {
 		"X-Frame-Options":        "DENY",
 		"X-XSS-Protection":       "1; mode=block",
 		"Referrer-Policy":        "strict-origin-when-cross-origin",
+	}
+
+	if pp := rec.Header().Get("Permissions-Policy"); pp == "" {
+		t.Error("Expected Permissions-Policy header to be set")
 	}
 
 	for header, expectedValue := range expectedHeaders {

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,11 +40,16 @@ http {
         root /usr/share/nginx/html;
         index templates/index.html;
 
-        # Security headers
+        # Security headers (defense-in-depth; Go backend also sets these).
+        # HSTS is intentionally NOT set here because this nginx.conf listens on
+        # plain HTTP for dev/test. Enable it in the production edge config only
+        # when TLS is terminated upstream:
+        #   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), interest-cohort=()" always;
 
         # Proxy API requests to Go backend
         location /api/ {


### PR DESCRIPTION
## Summary

Ran a broad security foot-gun audit of the Go backend, infra, and migrations. Only **low-risk, high-confidence** fixes were applied inline; everything else is documented below for follow-up PRs. No critical vulnerabilities found.

### Fixes in this PR

- **CORS wildcard + credentials (real foot-gun)** — `internal/middleware/middleware.go`. Previously when the allow-list contained `"*"` the middleware reflected the caller's `Origin` while also setting `Access-Control-Allow-Credentials: true`. Prod config validation already forbids `"*"`, so this was latent, but fixed anyway: wildcard mode now responds with literal `*` and omits the credentials header, matching browser rules. Exact-match origins still enable credentials.
- **`Permissions-Policy` header** — disables `geolocation`, `microphone`, `camera`, `payment`, `usb`, `magnetometer`, `gyroscope`, `accelerometer`, and `interest-cohort`. None are used by the app, so blocking them narrows the blast radius of any future XSS.
- **nginx.conf** — added `Permissions-Policy` at the edge and documented (commented) HSTS so it isn't enabled on the plain-HTTP dev listener by mistake.

All middleware unit tests updated and passing.

### Audit findings (not fixed in this PR)

Positives first: `go vet` is clean, bcrypt cost is 12, MFA secrets are AES-256-GCM with crypto/rand nonces, the JWT middleware rejects non-HMAC algorithms, the CSRF middleware uses `hmac.Equal` and crypto/rand, SQL queries throughout are parameterized, no `InsecureSkipVerify=true` exists, all outbound HTTP clients have timeouts, and the global 1 MB body limit + `MaxBytesReader` is wired up in the router.

**High-signal items worth follow-up PRs:**

1. **Per-route auth rate limits not applied at the router.** The CLAUDE.md-documented limits (login 10/5min, register 3/hr, forgot-password 5/15min, etc.) are enforced inside `internal/handlers/auth.go` but not wrapped by dedicated middleware in `router.go`. If the global limiter is misconfigured, brute-force targets lose their per-endpoint floor. Fix: wrap each auth endpoint with its own `RateLimitMiddleware` instance.
2. **JWT `nbf` claim not validated.** `internal/middleware/auth.go:116-137` — only `exp` is checked. Tokens with a future-dated `iat`/`nbf` but a valid signature are accepted early. Fix: validate `nbf` (jwt-go does this by default if the claim exists; ensure `ParseWithClaims` isn't overriding the default validator).
3. **Status cache optional on JWT auth.** `internal/middleware/auth.go:51-63` — if `SetStatusCache` isn't called, logout/block checks are silently skipped. Fix: make the cache required at construction, or fail-closed if nil.
4. **Vouch monthly limit checked post-transaction.** `internal/handlers/verification.go:1076` — the limit is enforced only after Mapbox calls run. Cheap early check would stop DoS loops earlier.
5. **Polygon vertex count unbounded on region create.** `internal/handlers/regions.go:231-252` — `ST_Contains` against a pathologically complex polygon burns CPU. Fix: cap vertex count (~10k) or call `ST_SimplifyPreserveTopology` before insert.
6. **`DisallowUnknownFields()` is not used on any JSON decoder.** Not exploitable today, but this is exactly how internal-only fields leak into user-controlled requests after a refactor. Blanket fix: thread it through the helper used in handlers.
7. **`template/index.html` ships the Mapbox public token hardcoded.** It's a `pk.*` token, which is designed for browser exposure, so not a security bug — but it should come from config so dev/staging/prod can use different tokens.
8. **nginx.conf has no HSTS and no rate limiting at the edge.** Backend rate-limits exist, but DDoS that exhausts upstream connections doesn't need to reach Go. Fix in the production edge config, not this dev file.
9. **`Dockerfile` production stage has no `HEALTHCHECK`.** Orchestrator-neutral liveness probe missing. Adding it would require bundling `wget`/`curl` in the minimal image, so leaving as a judgement call.
10. **CSRF exempts unauthenticated endpoints without Origin/Referer validation.** `internal/middleware/csrf.go:27-37`. Defense-in-depth only — these endpoints don't rely on ambient auth — but pairing it with an `Origin` check closes a small XSS+forged-request gap.
11. **`users.email` uniqueness** in `migrations/001_initial_schema.up.sql` should be verified case-insensitive. If collation is not `utf8mb4_unicode_ci`, add a functional unique index on `LOWER(email)`.
12. **Audit-log query builder** (`internal/database/audit.go:138,158`) uses `fmt.Sprintf` to stitch a pre-built `whereClause`. The conditions and column names are hardcoded and all values go through `?`, so this is NOT SQL injection as initially feared — flagged here to document the verdict for future auditors.
13. **NCES ArcGIS `WHERE` clause formatting** (`internal/services/nces.go:111,132,225`) uses `fmt.Sprintf` with `state`/`geoid` inputs. Inputs come from the `seed-schools` CLI and DB-stored NCES IDs, not user requests, so not exploitable today. Still worth a whitelist (two-letter state code, numeric GEOID) to future-proof.

Per the repo's `.gitignore` policy (`SECURITY_AUDIT.md` and `PII_SCAN_REPORT.md` are listed as "sensitive — never commit"), findings are kept in this PR body rather than checked in as a file.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/config/... ./internal/middleware/... ./internal/models/... ./internal/services/... ./internal/logging/...` — all pass
- [x] `go test -short ./internal/handlers/... ./internal/database/...` — all pass
- [x] Middleware tests updated to reflect new wildcard CORS behavior and Permissions-Policy header
- [ ] Manual: confirm edge config for production has HSTS + CSP + edge rate-limits separate from this dev nginx.conf