### PR TITLE
test: cover internal/logging and internal/database audit log

### DIFF
--- a/internal/database/audit_test.go
+++ b/internal/database/audit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -51,6 +52,31 @@ func cleanupAuditByResource(t *testing.T, db *DB, resourceID string) {
 	}
 }
 
+// createAuditTestUser inserts a real users row whose id can be used as a FK
+// target for audit_log.user_id. The user is removed in t.Cleanup. The email
+// and username are scoped with a UUID suffix to avoid collisions between
+// concurrently running tests.
+func createAuditTestUser(t *testing.T, db *DB, label string) *models.User {
+	t.Helper()
+	repo := NewUserRepository(db)
+	suffix := uuid.New().String()
+	user := &models.User{
+		Username:     "audit_" + label + "_" + suffix[:8],
+		Email:        "audit_" + label + "_" + suffix[:8] + "@example.test",
+		PasswordHash: "hash",
+	}
+	if err := repo.Create(context.Background(), user); err != nil {
+		t.Fatalf("failed to create test user (%s): %v", label, err)
+	}
+	t.Cleanup(func() {
+		// audit_log rows that reference this user are cleaned by
+		// resource-scoped DELETE in each test; the FK is ON DELETE SET NULL
+		// so deleting the user is safe even if any stragglers remain.
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM users WHERE id = ?", user.ID)
+	})
+	return user
+}
+
 func TestNewAuditRepository(t *testing.T) {
 	db := testDB(t)
 	repo := NewAuditRepository(db)
@@ -67,14 +93,14 @@ func TestAuditRepository_Log_Success(t *testing.T) {
 	repo := NewAuditRepository(db)
 	ctx := ctxWithRequest(t, "10.0.0.5", "test-agent/1.0")
 
-	userID := "audit-user-" + uniqueResourceID()
+	user := createAuditTestUser(t, db, "logsuccess")
 	resourceID := uniqueResourceID()
 	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
 
 	details := map[string]any{"foo": "bar", "n": 7}
 	resourceType := "test_resource"
 
-	if err := repo.Log(ctx, &userID, "test_action", &resourceType, &resourceID, details); err != nil {
+	if err := repo.Log(ctx, &user.ID, "test_action", &resourceType, &resourceID, details); err != nil {
 		t.Fatalf("Log returned error: %v", err)
 	}
 
@@ -89,8 +115,8 @@ func TestAuditRepository_Log_Success(t *testing.T) {
 	if err := row.Scan(&gotUserID, &gotAction, &gotResourceType, &gotResourceID, &gotDetails, &gotIP, &gotUA); err != nil {
 		t.Fatalf("failed to read back row: %v", err)
 	}
-	if gotUserID != userID {
-		t.Errorf("user_id = %q, want %q", gotUserID, userID)
+	if gotUserID != user.ID {
+		t.Errorf("user_id = %q, want %q", gotUserID, user.ID)
 	}
 	if gotAction != "test_action" {
 		t.Errorf("action = %q, want %q", gotAction, "test_action")
@@ -157,7 +183,13 @@ func TestAuditRepository_Log_TruncatesLongUserAgent(t *testing.T) {
 		t.Fatalf("failed to read user_agent: %v", err)
 	}
 	if len(storedUA) != 512 {
-		t.Errorf("user_agent length = %d, want 512", len(storedUA))
+		t.Fatalf("user_agent length = %d, want 512", len(storedUA))
+	}
+	// Ensure truncation preserved the original bytes rather than silently
+	// filling with zeroes or some other placeholder.
+	if want := strings.Repeat("A", 512); storedUA != want {
+		t.Errorf("user_agent content mismatch: got %q (first 32 bytes), want 512 'A's",
+			storedUA[:32])
 	}
 }
 
@@ -208,24 +240,21 @@ func seedAuditRows(t *testing.T, db *DB, repo *AuditRepository, count int) audit
 		resourceType: "seeded_resource",
 	}
 	for i := 0; i < count; i++ {
-		ip := "10.1.1." + intToStr(i+1)
-		ua := "agent-" + intToStr(i)
-		userID := "user-" + intToStr(i)
-		action := "action_" + intToStr(i)
+		ip := "10.1.1." + strconv.Itoa(i+1)
+		ua := "agent-" + strconv.Itoa(i)
+		// Each row references a real user so the FK constraint
+		// (audit_log.user_id -> users.id) is satisfied.
+		user := createAuditTestUser(t, db, "seed"+strconv.Itoa(i))
+		action := "action_" + strconv.Itoa(i)
 		ctx := ctxWithRequest(t, ip, ua)
-		if err := repo.Log(ctx, &userID, action, &seed.resourceType, &seed.resourceID, map[string]int{"i": i}); err != nil {
+		if err := repo.Log(ctx, &user.ID, action, &seed.resourceType, &seed.resourceID, map[string]int{"i": i}); err != nil {
 			t.Fatalf("seed Log #%d failed: %v", i, err)
 		}
-		seed.userIDs = append(seed.userIDs, userID)
+		seed.userIDs = append(seed.userIDs, user.ID)
 		seed.actions = append(seed.actions, action)
 		seed.ips = append(seed.ips, ip)
 	}
 	return seed
-}
-
-func intToStr(i int) string {
-	// avoid strconv to keep imports tidy
-	return uuid.NewSHA1(uuid.Nil, []byte{byte(i)}).String()[:8]
 }
 
 func TestAuditRepository_Query_Filtering(t *testing.T) {
@@ -446,20 +475,22 @@ func TestAuditRepository_DeleteOlderThan(t *testing.T) {
 	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
 
 	// Seed one "old" row by writing directly with a backdated created_at, and
-	// one "new" row through the repo so it gets a current timestamp.
+	// one "new" row through the repo so it gets a current timestamp. Both rows
+	// reference a real user so the FK constraint is satisfied.
+	oldUser := createAuditTestUser(t, db, "retentionold")
+	newUser := createAuditTestUser(t, db, "retentionnew")
+
 	oldID := uuid.New().String()
-	oldUser := "old-user"
 	oldTime := time.Now().UTC().Add(-200 * 24 * time.Hour) // 200 days ago
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO audit_log (id, user_id, action, resource_type, resource_id, created_at)
 		VALUES (?, ?, ?, ?, ?, ?)`,
-		oldID, oldUser, "old_action", resourceType, resourceID, oldTime,
+		oldID, oldUser.ID, "old_action", resourceType, resourceID, oldTime,
 	); err != nil {
 		t.Fatalf("failed to seed old row: %v", err)
 	}
 
-	newUser := "new-user"
-	if err := repo.Log(ctx, &newUser, "new_action", &resourceType, &resourceID, nil); err != nil {
+	if err := repo.Log(ctx, &newUser.ID, "new_action", &resourceType, &resourceID, nil); err != nil {
 		t.Fatalf("failed to seed new row via repo: %v", err)
 	}
 
@@ -504,7 +535,8 @@ func TestAuditRepository_DeleteOlderThan_Batching(t *testing.T) {
 	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
 
 	// Seed >1000 old rows in a single multi-value insert to exercise the
-	// batched delete loop (batchSize = 1000).
+	// batched delete loop (batchSize = 1000). user_id is NULL so we don't
+	// need to create 1050 real users — the FK accepts NULL.
 	const total = 1050
 	cutoff := time.Now().UTC().Add(-200 * 24 * time.Hour)
 

--- a/internal/database/audit_test.go
+++ b/internal/database/audit_test.go
@@ -1,0 +1,541 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opencrr/communityrapidresponse.net/internal/middleware"
+	"github.com/opencrr/communityrapidresponse.net/internal/models"
+)
+
+// ctxWithRequest builds a context populated by middleware.RequestContext with
+// the given client IP and user agent. RequestContext is the only public way to
+// set the ip / user-agent context keys, which are private to the middleware
+// package.
+func ctxWithRequest(t *testing.T, ip, userAgent string) context.Context {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = ip + ":1234"
+	req.Header.Set("User-Agent", userAgent)
+
+	var captured context.Context
+	handler := middleware.RequestContext(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = r.Context()
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if captured == nil {
+		t.Fatal("RequestContext middleware did not run handler")
+	}
+	return captured
+}
+
+// uniqueResourceID returns a UUID-shaped value that scopes a test's inserts so
+// we can clean them up without trampling other tests' rows.
+func uniqueResourceID() string {
+	return uuid.New().String()
+}
+
+// cleanupAuditByResource removes rows scoped to a single test's resource_id.
+func cleanupAuditByResource(t *testing.T, db *DB, resourceID string) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(),
+		"DELETE FROM audit_log WHERE resource_id = ?", resourceID); err != nil {
+		t.Logf("cleanup failed for resource_id=%s: %v", resourceID, err)
+	}
+}
+
+func TestNewAuditRepository(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	if repo == nil {
+		t.Fatal("NewAuditRepository returned nil")
+	}
+	if repo.db != db {
+		t.Error("repository did not retain the provided DB handle")
+	}
+}
+
+func TestAuditRepository_Log_Success(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := ctxWithRequest(t, "10.0.0.5", "test-agent/1.0")
+
+	userID := "audit-user-" + uniqueResourceID()
+	resourceID := uniqueResourceID()
+	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
+
+	details := map[string]any{"foo": "bar", "n": 7}
+	resourceType := "test_resource"
+
+	if err := repo.Log(ctx, &userID, "test_action", &resourceType, &resourceID, details); err != nil {
+		t.Fatalf("Log returned error: %v", err)
+	}
+
+	var (
+		gotUserID, gotAction, gotResourceType, gotResourceID string
+		gotDetails                                           []byte
+		gotIP, gotUA                                         *string
+	)
+	row := db.QueryRowContext(context.Background(), `
+		SELECT user_id, action, resource_type, resource_id, details, ip_address, user_agent
+		FROM audit_log WHERE resource_id = ?`, resourceID)
+	if err := row.Scan(&gotUserID, &gotAction, &gotResourceType, &gotResourceID, &gotDetails, &gotIP, &gotUA); err != nil {
+		t.Fatalf("failed to read back row: %v", err)
+	}
+	if gotUserID != userID {
+		t.Errorf("user_id = %q, want %q", gotUserID, userID)
+	}
+	if gotAction != "test_action" {
+		t.Errorf("action = %q, want %q", gotAction, "test_action")
+	}
+	if gotResourceType != resourceType {
+		t.Errorf("resource_type = %q, want %q", gotResourceType, resourceType)
+	}
+	if gotIP == nil || *gotIP != "10.0.0.5" {
+		t.Errorf("ip_address = %v, want 10.0.0.5", gotIP)
+	}
+	if gotUA == nil || *gotUA != "test-agent/1.0" {
+		t.Errorf("user_agent = %v, want test-agent/1.0", gotUA)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(gotDetails, &decoded); err != nil {
+		t.Fatalf("details JSON did not round-trip: %v (raw=%s)", err, string(gotDetails))
+	}
+	if decoded["foo"] != "bar" {
+		t.Errorf("details.foo = %v, want bar", decoded["foo"])
+	}
+}
+
+func TestAuditRepository_Log_NilDetails(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := context.Background()
+
+	resourceID := uniqueResourceID()
+	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
+
+	resourceType := "nil_details_resource"
+	if err := repo.Log(ctx, nil, "nil_details_action", &resourceType, &resourceID, nil); err != nil {
+		t.Fatalf("Log returned error: %v", err)
+	}
+
+	var detailsIsNull bool
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT details IS NULL FROM audit_log WHERE resource_id = ?", resourceID).Scan(&detailsIsNull); err != nil {
+		t.Fatalf("failed to read details column: %v", err)
+	}
+	if !detailsIsNull {
+		t.Error("expected details column to be NULL when details argument is nil")
+	}
+}
+
+func TestAuditRepository_Log_TruncatesLongUserAgent(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	longUA := strings.Repeat("A", 1024)
+	ctx := ctxWithRequest(t, "10.0.0.6", longUA)
+
+	resourceID := uniqueResourceID()
+	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
+
+	resourceType := "long_ua_resource"
+	if err := repo.Log(ctx, nil, "long_ua_action", &resourceType, &resourceID, nil); err != nil {
+		t.Fatalf("Log returned error: %v", err)
+	}
+
+	var storedUA string
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT user_agent FROM audit_log WHERE resource_id = ?", resourceID).Scan(&storedUA); err != nil {
+		t.Fatalf("failed to read user_agent: %v", err)
+	}
+	if len(storedUA) != 512 {
+		t.Errorf("user_agent length = %d, want 512", len(storedUA))
+	}
+}
+
+func TestAuditRepository_Log_EmptyContextOmitsIPAndUA(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+
+	resourceID := uniqueResourceID()
+	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
+
+	resourceType := "empty_ctx"
+	if err := repo.Log(context.Background(), nil, "empty_ctx_action", &resourceType, &resourceID, nil); err != nil {
+		t.Fatalf("Log returned error: %v", err)
+	}
+
+	var (
+		ipNull bool
+		uaNull bool
+	)
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT ip_address IS NULL, user_agent IS NULL FROM audit_log WHERE resource_id = ?",
+		resourceID).Scan(&ipNull, &uaNull); err != nil {
+		t.Fatalf("failed to read row: %v", err)
+	}
+	if !ipNull {
+		t.Error("expected ip_address to be NULL when context carries no IP")
+	}
+	if !uaNull {
+		t.Error("expected user_agent to be NULL when context carries no UA")
+	}
+}
+
+// auditTestSeed inserts rows scoped to a unique resource_id; the test should
+// use the returned resource_id to filter Query() calls and trust cleanup to
+// hit only this test's rows.
+type auditTestSeed struct {
+	resourceID   string
+	resourceType string
+	userIDs      []string
+	actions      []string
+	ips          []string
+}
+
+func seedAuditRows(t *testing.T, db *DB, repo *AuditRepository, count int) auditTestSeed {
+	t.Helper()
+	seed := auditTestSeed{
+		resourceID:   uniqueResourceID(),
+		resourceType: "seeded_resource",
+	}
+	for i := 0; i < count; i++ {
+		ip := "10.1.1." + intToStr(i+1)
+		ua := "agent-" + intToStr(i)
+		userID := "user-" + intToStr(i)
+		action := "action_" + intToStr(i)
+		ctx := ctxWithRequest(t, ip, ua)
+		if err := repo.Log(ctx, &userID, action, &seed.resourceType, &seed.resourceID, map[string]int{"i": i}); err != nil {
+			t.Fatalf("seed Log #%d failed: %v", i, err)
+		}
+		seed.userIDs = append(seed.userIDs, userID)
+		seed.actions = append(seed.actions, action)
+		seed.ips = append(seed.ips, ip)
+	}
+	return seed
+}
+
+func intToStr(i int) string {
+	// avoid strconv to keep imports tidy
+	return uuid.NewSHA1(uuid.Nil, []byte{byte(i)}).String()[:8]
+}
+
+func TestAuditRepository_Query_Filtering(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := context.Background()
+
+	seed := seedAuditRows(t, db, repo, 4)
+	t.Cleanup(func() { cleanupAuditByResource(t, db, seed.resourceID) })
+
+	t.Run("filters by resource id", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 4 {
+			t.Errorf("Total = %d, want 4", resp.Total)
+		}
+		if len(resp.Logs) != 4 {
+			t.Errorf("len(Logs) = %d, want 4", len(resp.Logs))
+		}
+	})
+
+	t.Run("filters by user id and resource id", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			UserID:     &seed.userIDs[1],
+			ResourceID: &seed.resourceID,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 1 {
+			t.Fatalf("Total = %d, want 1", resp.Total)
+		}
+		if resp.Logs[0].UserID == nil || *resp.Logs[0].UserID != seed.userIDs[1] {
+			t.Errorf("Logs[0].UserID = %v, want %q", resp.Logs[0].UserID, seed.userIDs[1])
+		}
+	})
+
+	t.Run("filters by actions list", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			Actions:    []string{seed.actions[0], seed.actions[2]},
+			ResourceID: &seed.resourceID,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 2 {
+			t.Errorf("Total = %d, want 2", resp.Total)
+		}
+	})
+
+	t.Run("filters by resource_type", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceType: &seed.resourceType,
+			ResourceID:   &seed.resourceID,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 4 {
+			t.Errorf("Total = %d, want 4", resp.Total)
+		}
+	})
+
+	t.Run("filters by ip_address", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			IPAddress:  &seed.ips[0],
+			ResourceID: &seed.resourceID,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 1 {
+			t.Errorf("Total = %d, want 1", resp.Total)
+		}
+	})
+
+	t.Run("filters by date_from in the future returns no rows", func(t *testing.T) {
+		future := time.Now().UTC().Add(48 * time.Hour)
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			DateFrom:   &future,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 0 {
+			t.Errorf("Total = %d, want 0", resp.Total)
+		}
+		if resp.Logs == nil {
+			t.Error("Logs should be an empty slice, not nil")
+		}
+	})
+
+	t.Run("filters by date_to in the past returns no rows", func(t *testing.T) {
+		past := time.Now().UTC().Add(-48 * time.Hour)
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			DateTo:     &past,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Total != 0 {
+			t.Errorf("Total = %d, want 0", resp.Total)
+		}
+	})
+}
+
+func TestAuditRepository_Query_PaginationDefaults(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := context.Background()
+
+	seed := seedAuditRows(t, db, repo, 3)
+	t.Cleanup(func() { cleanupAuditByResource(t, db, seed.resourceID) })
+
+	t.Run("Page<1 defaults to 1", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			Page:       0,
+			Limit:      10,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Page != 1 {
+			t.Errorf("Page = %d, want 1", resp.Page)
+		}
+	})
+
+	t.Run("Limit<1 defaults to 50", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			Limit:      0,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Limit != 50 {
+			t.Errorf("Limit = %d, want 50", resp.Limit)
+		}
+	})
+
+	t.Run("Limit>100 clamps to 100", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			Limit:      500,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.Limit != 100 {
+			t.Errorf("Limit = %d, want 100", resp.Limit)
+		}
+	})
+
+	t.Run("HasMore true when there are more pages", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			Page:       1,
+			Limit:      2,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if !resp.HasMore {
+			t.Errorf("HasMore = false; want true (total=%d, page=%d, limit=%d)", resp.Total, resp.Page, resp.Limit)
+		}
+		if len(resp.Logs) != 2 {
+			t.Errorf("len(Logs) on page 1 = %d, want 2", len(resp.Logs))
+		}
+	})
+
+	t.Run("HasMore false on last page", func(t *testing.T) {
+		resp, err := repo.Query(ctx, models.AuditLogFilter{
+			ResourceID: &seed.resourceID,
+			Page:       2,
+			Limit:      2,
+		})
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if resp.HasMore {
+			t.Errorf("HasMore = true; want false (total=%d, page=%d, limit=%d)", resp.Total, resp.Page, resp.Limit)
+		}
+	})
+}
+
+func TestAuditRepository_Query_EmptyResultIsNonNilSlice(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := context.Background()
+
+	unused := uniqueResourceID()
+	resp, err := repo.Query(ctx, models.AuditLogFilter{ResourceID: &unused})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Errorf("Total = %d, want 0", resp.Total)
+	}
+	if resp.Logs == nil {
+		t.Error("expected Logs to be an empty slice, got nil")
+	}
+}
+
+func TestAuditRepository_DeleteOlderThan(t *testing.T) {
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := context.Background()
+
+	resourceID := uniqueResourceID()
+	resourceType := "retention_test"
+	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
+
+	// Seed one "old" row by writing directly with a backdated created_at, and
+	// one "new" row through the repo so it gets a current timestamp.
+	oldID := uuid.New().String()
+	oldUser := "old-user"
+	oldTime := time.Now().UTC().Add(-200 * 24 * time.Hour) // 200 days ago
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO audit_log (id, user_id, action, resource_type, resource_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		oldID, oldUser, "old_action", resourceType, resourceID, oldTime,
+	); err != nil {
+		t.Fatalf("failed to seed old row: %v", err)
+	}
+
+	newUser := "new-user"
+	if err := repo.Log(ctx, &newUser, "new_action", &resourceType, &resourceID, nil); err != nil {
+		t.Fatalf("failed to seed new row via repo: %v", err)
+	}
+
+	deleted, err := repo.DeleteOlderThan(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("DeleteOlderThan returned error: %v", err)
+	}
+	if deleted < 1 {
+		t.Errorf("expected at least 1 row deleted, got %d", deleted)
+	}
+
+	// The "new" row must still be present; the "old" row must be gone.
+	var remaining int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM audit_log WHERE resource_id = ?", resourceID).Scan(&remaining); err != nil {
+		t.Fatalf("failed to count remaining rows: %v", err)
+	}
+	if remaining != 1 {
+		t.Errorf("remaining rows = %d, want 1", remaining)
+	}
+
+	var oldStillThere int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM audit_log WHERE id = ?", oldID).Scan(&oldStillThere); err != nil {
+		t.Fatalf("failed to check for old row: %v", err)
+	}
+	if oldStillThere != 0 {
+		t.Error("old row should have been deleted")
+	}
+}
+
+func TestAuditRepository_DeleteOlderThan_Batching(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping batch deletion test in short mode")
+	}
+	db := testDB(t)
+	repo := NewAuditRepository(db)
+	ctx := context.Background()
+
+	resourceID := uniqueResourceID()
+	resourceType := "retention_batch"
+	t.Cleanup(func() { cleanupAuditByResource(t, db, resourceID) })
+
+	// Seed >1000 old rows in a single multi-value insert to exercise the
+	// batched delete loop (batchSize = 1000).
+	const total = 1050
+	cutoff := time.Now().UTC().Add(-200 * 24 * time.Hour)
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO audit_log (id, action, resource_type, resource_id, created_at) VALUES ")
+	args := make([]any, 0, total*5)
+	for i := 0; i < total; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("(?, ?, ?, ?, ?)")
+		args = append(args, uuid.New().String(), "batch_action", resourceType, resourceID, cutoff)
+	}
+	if _, err := db.ExecContext(ctx, sb.String(), args...); err != nil {
+		t.Fatalf("failed to bulk-insert seed rows: %v", err)
+	}
+
+	deleted, err := repo.DeleteOlderThan(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("DeleteOlderThan returned error: %v", err)
+	}
+	if deleted < total {
+		t.Errorf("deleted = %d, want at least %d (all old rows)", deleted, total)
+	}
+
+	var remaining int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM audit_log WHERE resource_id = ?", resourceID).Scan(&remaining); err != nil {
+		t.Fatalf("failed to count remaining rows: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("remaining rows = %d, want 0", remaining)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,183 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"unknown", slog.LevelInfo},
+		{"DEBUG", slog.LevelInfo}, // case-sensitive
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := parseLevel(tc.in); got != tc.want {
+				t.Errorf("parseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithRequestIDAndRequestID(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		ctx := WithRequestID(context.Background(), "abc-123")
+		if got := RequestID(ctx); got != "abc-123" {
+			t.Errorf("RequestID = %q, want %q", got, "abc-123")
+		}
+	})
+
+	t.Run("missing key returns empty string", func(t *testing.T) {
+		if got := RequestID(context.Background()); got != "" {
+			t.Errorf("RequestID(empty ctx) = %q, want \"\"", got)
+		}
+	})
+
+	t.Run("wrong-type value returns empty string", func(t *testing.T) {
+		// Insert a non-string value under the same key.
+		ctx := context.WithValue(context.Background(), requestIDKey, 42)
+		if got := RequestID(ctx); got != "" {
+			t.Errorf("RequestID(int-valued ctx) = %q, want \"\"", got)
+		}
+	})
+
+	t.Run("overwrites prior request id", func(t *testing.T) {
+		ctx := WithRequestID(context.Background(), "first")
+		ctx = WithRequestID(ctx, "second")
+		if got := RequestID(ctx); got != "second" {
+			t.Errorf("RequestID = %q, want %q", got, "second")
+		}
+	})
+}
+
+// captureJSON runs h.Handle with the given context and returns the parsed JSON
+// record emitted to buf.
+func captureJSON(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("failed to parse json output %q: %v", buf.String(), err)
+	}
+	return out
+}
+
+func newJSONHandler(buf *bytes.Buffer) *contextHandler {
+	base := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return &contextHandler{base: base}
+}
+
+func TestContextHandler_Handle_InjectsRequestID(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := newJSONHandler(buf)
+
+	ctx := WithRequestID(context.Background(), "req-42")
+	logger := slog.New(h)
+	logger.InfoContext(ctx, "hello")
+
+	rec := captureJSON(t, buf)
+	if got, _ := rec["request_id"].(string); got != "req-42" {
+		t.Errorf("request_id attr = %v, want %q", rec["request_id"], "req-42")
+	}
+	if got, _ := rec["msg"].(string); got != "hello" {
+		t.Errorf("msg = %v, want %q", rec["msg"], "hello")
+	}
+}
+
+func TestContextHandler_Handle_OmitsRequestIDWhenMissing(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := newJSONHandler(buf)
+
+	logger := slog.New(h)
+	logger.InfoContext(context.Background(), "no id")
+
+	rec := captureJSON(t, buf)
+	if _, present := rec["request_id"]; present {
+		t.Errorf("expected no request_id key, got %v", rec["request_id"])
+	}
+}
+
+func TestContextHandler_Enabled_DelegatesToBase(t *testing.T) {
+	buf := &bytes.Buffer{}
+	base := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	h := &contextHandler{base: base}
+
+	if h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("Enabled(Debug) should be false when base level is Warn")
+	}
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Error("Enabled(Error) should be true when base level is Warn")
+	}
+}
+
+func TestContextHandler_WithAttrs_StillInjectsRequestID(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := newJSONHandler(buf)
+
+	wrapped := h.WithAttrs([]slog.Attr{slog.String("component", "auth")})
+	if _, ok := wrapped.(*contextHandler); !ok {
+		t.Fatalf("WithAttrs should return *contextHandler, got %T", wrapped)
+	}
+
+	logger := slog.New(wrapped)
+	ctx := WithRequestID(context.Background(), "req-99")
+	logger.InfoContext(ctx, "msg")
+
+	rec := captureJSON(t, buf)
+	if got, _ := rec["request_id"].(string); got != "req-99" {
+		t.Errorf("request_id = %v, want %q", rec["request_id"], "req-99")
+	}
+	if got, _ := rec["component"].(string); got != "auth" {
+		t.Errorf("component attr lost: got %v", rec["component"])
+	}
+}
+
+func TestContextHandler_WithGroup_StillInjectsRequestID(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := newJSONHandler(buf)
+
+	wrapped := h.WithGroup("svc")
+	if _, ok := wrapped.(*contextHandler); !ok {
+		t.Fatalf("WithGroup should return *contextHandler, got %T", wrapped)
+	}
+
+	logger := slog.New(wrapped)
+	ctx := WithRequestID(context.Background(), "req-grp")
+	logger.InfoContext(ctx, "msg", slog.String("k", "v"))
+
+	rec := captureJSON(t, buf)
+	// request_id is added at the top level (not inside the group) because
+	// AddAttrs on the record runs before the group prefix is applied to
+	// subsequent attributes. Either way, it should still be present and
+	// resolve to the expected value somewhere in the record.
+	if got, _ := rec["request_id"].(string); got != "req-grp" {
+		// Fall back: it may have ended up inside the group.
+		if grp, ok := rec["svc"].(map[string]any); ok {
+			if got, _ := grp["request_id"].(string); got == "req-grp" {
+				return
+			}
+		}
+		t.Errorf("request_id not found after WithGroup; record = %v", rec)
+	}
+}
+
+func TestInit_DoesNotPanic(t *testing.T) {
+	// Init mutates slog's default logger. Save and restore.
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	Init("json", "debug")
+	Init("text", "warn")
+	Init("text", "") // exercises default level branch
+}


### PR DESCRIPTION
## Summary

Closes the two highest-value test-coverage gaps in `internal/`:

- **`internal/logging`** — pure-logic request-id propagation. Now at **100% statement coverage** (`parseLevel`, `WithRequestID` / `RequestID` round-trip incl. wrong-type values, the `contextHandler` request_id injection, plus `Enabled` / `WithAttrs` / `WithGroup` delegation). JSON output captured to a `bytes.Buffer` and parsed for asserts; no dependence on a database.
- **`internal/database/audit`** — security-critical audit logging with the 90-day retention mandated by CLAUDE.md's Security section. Covers `Log` (success path, nil details → SQL NULL, >512-byte user-agent truncation, missing-context fallback), `Query` (per-field filters: user/actions/resource type/resource id/ip/date range; pagination defaults & clamping at 1/50/100; `HasMore`; empty result is non-nil slice), and `DeleteOlderThan` (retention boundary + a >1000-row seed to exercise the batched delete loop). Uses the existing `testDB()` skip pattern from `database_test.go`, so the tests run against CI's MariaDB and skip cleanly on dev machines without `TEST_DB_HOST`.

No production code was modified — this PR is purely additive test coverage.

## Test-gap inventory (follow-up checklist)

While here I audited `internal/` for files in non-models packages with no `*_test.go` sibling. The list below is everything still uncovered after this PR.

- [ ] `internal/handlers/router.go`
- [ ] `internal/services/nces.go`
- [ ] `internal/services/email_sendgrid.go`
- [ ] `internal/services/email_mock.go`
- [ ] `internal/services/notification_queue.go`
- [ ] `internal/database/regions.go`
- [ ] `internal/database/signal_groups.go`
- [ ] `internal/database/school_districts.go`
- [ ] `internal/database/school_vouches.go`
- [ ] `internal/database/secret_update_proposals.go`
- [ ] `internal/database/user_reports.go`
- [ ] `internal/database/meshtastic_channels.go`
- [ ] `internal/database/encrypted_secrets.go`
- [ ] `internal/database/encryption_keys.go`
- [ ] `internal/database/errors.go` helpers
- [ ] `internal/middleware/request_context.go` (exercised transitively by the new audit tests but no dedicated test file)
- [x] `internal/logging/logging.go` (this PR)
- [x] `internal/database/audit.go` (this PR)

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/logging/...` — passes, 100% statement coverage
- [x] `go test -run NONE ./internal/database/...` — compiles cleanly
- [x] `go test -v -run TestAuditRepository ./internal/database/...` — all subtests skip cleanly when `TEST_DB_HOST` is unset
- [ ] CI: `go test ./internal/database/...` against CI's MariaDB exercises the audit subtests for real

Nightshift-Task: test-gap
Nightshift-Ref: https://github.com/marcus/nightshift