### PR TITLE
improve: add context to handler error messages

### DIFF
--- a/internal/handlers/regions.go
+++ b/internal/handlers/regions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -504,7 +505,7 @@ func (h *RegionHandler) autoCreateParentRegions(ctx context.Context, req models.
 			// Auto-detect state from coordinates using reverse geocoding
 			detectedState, err := h.detectStateFromCoordinates(ctx, lat, lng)
 			if err != nil {
-				return nil, errors.New("could not determine state from location: " + err.Error())
+				return nil, fmt.Errorf("could not determine state for coordinates (%f, %f): %w", lat, lng, err)
 			}
 			stateName = detectedState
 			slog.Info("auto-detected state", "state", stateName)
@@ -525,7 +526,7 @@ func (h *RegionHandler) autoCreateParentRegions(ctx context.Context, req models.
 			// Auto-detect county and state from coordinates
 			countyBoundary, err := h.mapboxService.GetCountyForCoordinates(ctx, lat, lng, "")
 			if err != nil {
-				return nil, errors.New("could not determine county from location: " + err.Error())
+				return nil, fmt.Errorf("could not determine county for coordinates (%f, %f): %w", lat, lng, err)
 			}
 			if countyName == "" {
 				countyName = countyBoundary.Name
@@ -551,11 +552,11 @@ func (h *RegionHandler) autoCreateParentRegions(ctx context.Context, req models.
 
 	case models.RegionTypeNeighborhood:
 		// Neighborhood requires an existing City parent
-		return nil, errors.New("neighborhood regions must have an existing city parent")
+		return nil, errors.New("neighborhood regions require parent_id of an existing city region")
 
 	case models.RegionTypeCityBlock:
 		// CityBlock requires an existing Neighborhood parent
-		return nil, errors.New("city block regions must have an existing neighborhood parent")
+		return nil, errors.New("city block regions require parent_id of an existing neighborhood region")
 	}
 
 	return nil, nil
@@ -569,7 +570,7 @@ func (h *RegionHandler) detectStateFromCoordinates(ctx context.Context, lat, lng
 		return "", err
 	}
 	if countyBoundary.State == "" {
-		return "", errors.New("could not determine state from coordinates")
+		return "", fmt.Errorf("could not determine state from coordinates (%f, %f): reverse geocode returned no state", lat, lng)
 	}
 	return countyBoundary.State, nil
 }

--- a/internal/handlers/regions_test.go
+++ b/internal/handlers/regions_test.go
@@ -373,7 +373,7 @@ func TestRegionHandler_Create_TypeHierarchy(t *testing.T) {
 			regionType: models.RegionTypeNeighborhood,
 			parentID:   nil,
 			shouldFail: true,
-			errorMsg:   "neighborhood regions must have an existing city parent",
+			errorMsg:   "neighborhood regions require parent_id of an existing city region",
 		},
 		{
 			name:       "neighborhood with neighborhood parent should fail",
@@ -387,7 +387,7 @@ func TestRegionHandler_Create_TypeHierarchy(t *testing.T) {
 			regionType: models.RegionTypeCityBlock,
 			parentID:   nil,
 			shouldFail: true,
-			errorMsg:   "city block regions must have an existing neighborhood parent",
+			errorMsg:   "city block regions require parent_id of an existing neighborhood region",
 		},
 		{
 			name:       "city_block with city parent should fail",

--- a/internal/handlers/secret_updates.go
+++ b/internal/handlers/secret_updates.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/opencrr/communityrapidresponse.net/internal/config"
@@ -539,7 +540,7 @@ func (h *SecretUpdateHandler) resolveGroupScope(w http.ResponseWriter, r *http.R
 	}
 	if !group.IsActive {
 		writeError(w, http.StatusNotFound, "not_found", "Signal group not found")
-		return nil, nil, nil, 0, errors.New("signal group inactive")
+		return nil, nil, nil, 0, fmt.Errorf("signal group %s is inactive", groupID)
 	}
 
 	if group.RegionID != nil {
@@ -565,7 +566,7 @@ func (h *SecretUpdateHandler) resolveMeshtasticScope(w http.ResponseWriter, r *h
 	}
 	if !channel.IsActive {
 		writeError(w, http.StatusNotFound, "not_found", "Meshtastic channel not found")
-		return nil, nil, nil, 0, errors.New("meshtastic channel inactive")
+		return nil, nil, nil, 0, fmt.Errorf("meshtastic channel %s is inactive", channelID)
 	}
 
 	if channel.RegionID != nil {
@@ -594,7 +595,7 @@ func (h *SecretUpdateHandler) verifyAdminAccess(w http.ResponseWriter, r *http.R
 		return h.verifyDistrictAdmin(w, r, claims, *districtID)
 	}
 	writeError(w, http.StatusBadRequest, "invalid_scope", "Proposal has no valid scope")
-	return 0, errors.New("no scope")
+	return 0, errors.New("proposal has no region, school, or district scope")
 }
 
 // verifyRegionAdmin checks if user is admin of a region and returns admin count
@@ -607,7 +608,7 @@ func (h *SecretUpdateHandler) verifyRegionAdmin(w http.ResponseWriter, r *http.R
 		}
 		if !isAdmin {
 			writeError(w, http.StatusForbidden, "forbidden", "Admin access required")
-			return 0, errors.New("not admin")
+			return 0, fmt.Errorf("user %s is not an admin of region %s", claims.UserID, regionID)
 		}
 	}
 	adminCount, err := h.regionRepo.GetAdminCount(r.Context(), regionID)
@@ -628,7 +629,7 @@ func (h *SecretUpdateHandler) verifySchoolAdmin(w http.ResponseWriter, r *http.R
 		}
 		if userSchool == nil || !userSchool.IsAdmin || userSchool.VerificationStatus != models.SchoolVerificationStatusVerified {
 			writeError(w, http.StatusForbidden, "forbidden", "School admin access required")
-			return 0, errors.New("not school admin")
+			return 0, fmt.Errorf("user %s is not a verified admin of school %s", claims.UserID, schoolID)
 		}
 	}
 	adminCount, err := h.schoolRepo.GetVerifiedAdminCount(r.Context(), schoolID)
@@ -661,7 +662,7 @@ func (h *SecretUpdateHandler) verifyDistrictAdmin(w http.ResponseWriter, r *http
 		}
 		if !isDistrictAdmin {
 			writeError(w, http.StatusForbidden, "forbidden", "District admin access required")
-			return 0, errors.New("not district admin")
+			return 0, fmt.Errorf("user %s is not a verified admin of any school in district %s", claims.UserID, districtID)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Focused, minimal improvements to ~9 of the worst internal error messages in two handler files. **User-facing `writeError()` JSON responses are intentionally left unchanged** — they are already reasonable and modifying them risks breaking API consumers.

### `internal/handlers/secret_updates.go` — bare `errors.New` → `fmt.Errorf` with identifiers

These errors get returned up the call stack and used for server-side logging/debugging. Adding the relevant ID makes the logs diagnosable.

| Before | After |
|---|---|
| `errors.New(\"signal group inactive\")` | `fmt.Errorf(\"signal group %s is inactive\", groupID)` |
| `errors.New(\"meshtastic channel inactive\")` | `fmt.Errorf(\"meshtastic channel %s is inactive\", channelID)` |
| `errors.New(\"no scope\")` | `errors.New(\"proposal has no region, school, or district scope\")` |
| `errors.New(\"not admin\")` | `fmt.Errorf(\"user %s is not an admin of region %s\", claims.UserID, regionID)` |
| `errors.New(\"not school admin\")` | `fmt.Errorf(\"user %s is not a verified admin of school %s\", claims.UserID, schoolID)` |
| `errors.New(\"not district admin\")` | `fmt.Errorf(\"user %s is not a verified admin of any school in district %s\", claims.UserID, districtID)` |

### `internal/handlers/regions.go` — preserve error chain via `%w`; enrich with coords

The first two switch string-concatenation wrapping (`err.Error()`) to `%w` so `errors.Is`/`errors.As` keep working downstream against the underlying mapbox error chain. They also include the coordinates that the geocoder failed on.

| Before | After |
|---|---|
| `errors.New(\"could not determine state from location: \" + err.Error())` | `fmt.Errorf(\"could not determine state for coordinates (%f, %f): %w\", lat, lng, err)` |
| `errors.New(\"could not determine county from location: \" + err.Error())` | `fmt.Errorf(\"could not determine county for coordinates (%f, %f): %w\", lat, lng, err)` |
| `errors.New(\"could not determine state from coordinates\")` | `fmt.Errorf(\"could not determine state from coordinates (%f, %f): reverse geocode returned no state\", lat, lng)` |

The remaining two are user-facing (returned via the create-region handler) and tell the client which required field is missing:

| Before | After |
|---|---|
| `\"neighborhood regions must have an existing city parent\"` | `\"neighborhood regions require parent_id of an existing city region\"` |
| `\"city block regions must have an existing neighborhood parent\"` | `\"city block regions require parent_id of an existing neighborhood region\"` |

Updated the two corresponding assertions in `regions_test.go`.

### Scope

Deliberately excluded:
- `services/` layer (mapbox, postgrid, mfa) — separate dedicated PR
- The larger duplicated validation-string cleanup in `regions.go` region-type validation — warrants its own PR

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short` all packages pass
- [x] Confirmed no other tests assert on the old error strings

Nightshift-Task: error-msg-improve
Nightshift-Ref: https://github.com/marcus/nightshift