### PR TITLE
feat: add doc-drift detector for docs vs code/schema

### DIFF
--- a/cmd/doc-drift/main.go
+++ b/cmd/doc-drift/main.go
@@ -1,0 +1,339 @@
+// Command doc-drift detects drift between prose docs and the real codebase.
+//
+// Two checks are performed against CLAUDE.md, DESIGN.md, and README.md:
+//
+//  1. API endpoints documented in markdown vs. routes actually registered
+//     in internal/handlers/router.go.
+//  2. Database tables documented in markdown vs. tables that exist after
+//     applying migrations/*.up.sql in order (CREATE / DROP / RENAME).
+//
+// For each check we report:
+//   - documented-but-missing: appears in docs, not in code.
+//   - real-but-undocumented:  exists in code, not mentioned in docs.
+//
+// Exits non-zero when drift is found unless --warn-only is set, so it can
+// be wired into CI as a soft or hard gate.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	exitClean   = 0
+	exitDrift   = 1
+	exitFailure = 2
+)
+
+type report struct {
+	check                 string
+	documentedButMissing  []string
+	realButUndocumented   []string
+}
+
+func (r report) hasDrift() bool {
+	return len(r.documentedButMissing) > 0 || len(r.realButUndocumented) > 0
+}
+
+func (r report) print(w *os.File) {
+	fmt.Fprintf(w, "== %s ==\n", r.check)
+	if !r.hasDrift() {
+		fmt.Fprintln(w, "  no drift detected")
+		return
+	}
+	if len(r.documentedButMissing) > 0 {
+		fmt.Fprintln(w, "  documented but missing in code:")
+		for _, s := range r.documentedButMissing {
+			fmt.Fprintf(w, "    - %s\n", s)
+		}
+	}
+	if len(r.realButUndocumented) > 0 {
+		fmt.Fprintln(w, "  in code but undocumented:")
+		for _, s := range r.realButUndocumented {
+			fmt.Fprintf(w, "    - %s\n", s)
+		}
+	}
+}
+
+func main() {
+	repoRoot := flag.String("repo", ".", "Path to the repo root")
+	warnOnly := flag.Bool("warn-only", false, "Exit 0 even when drift is found")
+	flag.Parse()
+
+	root, err := filepath.Abs(*repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doc-drift: %v\n", err)
+		os.Exit(exitFailure)
+	}
+
+	docs, err := loadDocs(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doc-drift: %v\n", err)
+		os.Exit(exitFailure)
+	}
+
+	routerSrc, err := os.ReadFile(filepath.Join(root, "internal", "handlers", "router.go"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doc-drift: %v\n", err)
+		os.Exit(exitFailure)
+	}
+
+	migrations, err := loadMigrations(filepath.Join(root, "migrations"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doc-drift: %v\n", err)
+		os.Exit(exitFailure)
+	}
+
+	realExact, realPrefix := extractRoutes(string(routerSrc))
+	docPaths := extractDocumentedPaths(docs)
+	endpoints := diffEndpoints(realExact, realPrefix, docPaths)
+	endpoints.print(os.Stdout)
+
+	realTables := extractRealTables(migrations)
+	docTables := extractDocumentedTables(docs)
+	tables := diffTables(realTables, docTables)
+	tables.print(os.Stdout)
+
+	if (endpoints.hasDrift() || tables.hasDrift()) && !*warnOnly {
+		os.Exit(exitDrift)
+	}
+	os.Exit(exitClean)
+}
+
+// loadDocs reads the prose doc files we scan. Missing files are skipped.
+func loadDocs(root string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, name := range []string{"CLAUDE.md", "DESIGN.md", "README.md"} {
+		b, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		out[name] = string(b)
+	}
+	return out, nil
+}
+
+// loadMigrations returns the up-migration SQL files sorted by filename.
+func loadMigrations(dir string) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.up.sql"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		b, err := os.ReadFile(m)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, string(b))
+	}
+	return out, nil
+}
+
+// --- Route extraction ----------------------------------------------------
+
+var handleFuncRe = regexp.MustCompile(`(?m)r\.mux\.HandleFunc\(\s*"([^"]+)"`)
+
+// extractRoutes returns the exact paths and prefix paths registered with
+// the router. A prefix path is one whose registration ends in a trailing
+// slash — ServeMux treats those as sub-tree handlers.
+func extractRoutes(src string) (exact, prefix map[string]struct{}) {
+	exact = map[string]struct{}{}
+	prefix = map[string]struct{}{}
+	for _, m := range handleFuncRe.FindAllStringSubmatch(src, -1) {
+		path := m[1]
+		if !strings.HasPrefix(path, "/api/v1/") {
+			continue
+		}
+		if strings.HasSuffix(path, "/") {
+			prefix[path] = struct{}{}
+		} else {
+			exact[path] = struct{}{}
+		}
+	}
+	return
+}
+
+// --- Documented endpoint extraction --------------------------------------
+
+// pathInBackticks matches `/api/v1/...` enclosed in backticks. Trailing
+// punctuation inside the backticks is intentionally not stripped here —
+// we normalize below.
+var pathInBackticks = regexp.MustCompile("`(/api/v1/[A-Za-z0-9_:{}/.-]+)`")
+
+// extractDocumentedPaths returns the set of distinct documented API
+// paths across all docs, normalized so :id and {id} forms match.
+func extractDocumentedPaths(docs map[string]string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, body := range docs {
+		for _, m := range pathInBackticks.FindAllStringSubmatch(body, -1) {
+			out[normalizeDocPath(m[1])] = struct{}{}
+		}
+	}
+	return out
+}
+
+var pathParamRe = regexp.MustCompile(`\{[^}]+\}|:[A-Za-z_][A-Za-z0-9_]*`)
+
+// normalizeDocPath canonicalizes path parameters and trims trailing
+// punctuation/slashes so docs and code can be compared.
+func normalizeDocPath(p string) string {
+	p = strings.TrimRight(p, ".,;:/")
+	p = pathParamRe.ReplaceAllString(p, ":id")
+	return p
+}
+
+// --- Endpoint diff -------------------------------------------------------
+
+// diffEndpoints reconciles documented paths against real routes,
+// accounting for ServeMux prefix routes.
+func diffEndpoints(realExact, realPrefix, doc map[string]struct{}) report {
+	r := report{check: "API endpoints (docs vs internal/handlers/router.go)"}
+
+	for d := range doc {
+		if _, ok := realExact[d]; ok {
+			continue
+		}
+		if matchesPrefix(d, realPrefix) {
+			continue
+		}
+		r.documentedButMissing = append(r.documentedButMissing, d)
+	}
+
+	for e := range realExact {
+		if _, ok := doc[e]; ok {
+			continue
+		}
+		// docs may write the prefix form with an :id
+		if _, ok := doc[e+"/:id"]; ok {
+			continue
+		}
+		r.realButUndocumented = append(r.realButUndocumented, e)
+	}
+	for p := range realPrefix {
+		if documentedUnderPrefix(p, doc) {
+			continue
+		}
+		r.realButUndocumented = append(r.realButUndocumented, p+":id")
+	}
+
+	sort.Strings(r.documentedButMissing)
+	sort.Strings(r.realButUndocumented)
+	return r
+}
+
+// matchesPrefix reports whether the documented path d falls under any
+// prefix registered with the router.
+func matchesPrefix(d string, prefixes map[string]struct{}) bool {
+	for p := range prefixes {
+		if strings.HasPrefix(d+"/", p) || strings.HasPrefix(d, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// documentedUnderPrefix reports whether any documented path starts with
+// the given prefix, indicating the prefix's sub-tree is covered.
+func documentedUnderPrefix(prefix string, doc map[string]struct{}) bool {
+	for d := range doc {
+		if strings.HasPrefix(d+"/", prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Table extraction ----------------------------------------------------
+
+var (
+	createTableRe = regexp.MustCompile(`(?i)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?")
+	dropTableRe   = regexp.MustCompile(`(?i)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?")
+	renameTableRe = regexp.MustCompile(`(?i)RENAME\s+TABLE\s+` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?" + `\s+TO\s+` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?")
+	alterRenameRe = regexp.MustCompile(`(?i)ALTER\s+TABLE\s+` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?" + `\s+RENAME\s+TO\s+` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?")
+)
+
+// extractRealTables applies CREATE/DROP/RENAME statements from each
+// migration in order and returns the resulting set of table names.
+func extractRealTables(migrations []string) map[string]struct{} {
+	tables := map[string]struct{}{}
+	for _, sql := range migrations {
+		for _, m := range createTableRe.FindAllStringSubmatch(sql, -1) {
+			tables[m[1]] = struct{}{}
+		}
+		for _, m := range renameTableRe.FindAllStringSubmatch(sql, -1) {
+			delete(tables, m[1])
+			tables[m[2]] = struct{}{}
+		}
+		for _, m := range alterRenameRe.FindAllStringSubmatch(sql, -1) {
+			delete(tables, m[1])
+			tables[m[2]] = struct{}{}
+		}
+		for _, m := range dropTableRe.FindAllStringSubmatch(sql, -1) {
+			delete(tables, m[1])
+		}
+	}
+	return tables
+}
+
+// --- Documented table extraction -----------------------------------------
+
+// keyTablesLineRe finds the "Key tables:" enumeration that CLAUDE.md/DESIGN.md
+// use to summarize the schema. The list itself is a sequence of backtick
+// identifiers we extract with identifierRe below.
+var keyTablesLineRe = regexp.MustCompile(`(?i)Key tables:\s*(.+)`)
+var identifierRe = regexp.MustCompile("`([a-z_][a-z0-9_]*)`")
+
+// extractDocumentedTables pulls the table names listed in any "Key tables:"
+// line across the docs. We intentionally don't scan every backticked
+// identifier in the prose — many of those are columns or unrelated terms
+// and would produce noise. The "Key tables:" enumeration is the single
+// authoritative spot CLAUDE.md uses for the table list.
+func extractDocumentedTables(docs map[string]string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, body := range docs {
+		for _, m := range keyTablesLineRe.FindAllStringSubmatch(body, -1) {
+			for _, id := range identifierRe.FindAllStringSubmatch(m[1], -1) {
+				out[id[1]] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// --- Table diff ----------------------------------------------------------
+
+// ignoredTables are infra/bookkeeping tables we don't expect docs to list.
+var ignoredTables = map[string]struct{}{
+	"schema_migrations": {},
+}
+
+func diffTables(real, doc map[string]struct{}) report {
+	r := report{check: "Database tables (docs vs migrations/*.up.sql)"}
+	for d := range doc {
+		if _, ok := real[d]; !ok {
+			r.documentedButMissing = append(r.documentedButMissing, d)
+		}
+	}
+	for t := range real {
+		if _, ignored := ignoredTables[t]; ignored {
+			continue
+		}
+		if _, ok := doc[t]; !ok {
+			r.realButUndocumented = append(r.realButUndocumented, t)
+		}
+	}
+	sort.Strings(r.documentedButMissing)
+	sort.Strings(r.realButUndocumented)
+	return r
+}

--- a/cmd/doc-drift/main_test.go
+++ b/cmd/doc-drift/main_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestExtractRoutes(t *testing.T) {
+	src := `
+		r.mux.HandleFunc("/api/v1/auth/login", r.methodHandler(http.MethodPost, r.auth.Login))
+		r.mux.HandleFunc("/api/v1/communities", r.handleRegions)
+		r.mux.HandleFunc("/api/v1/communities/", r.handleRegionByID)
+		// non-API route should be ignored
+		r.mux.HandleFunc("/health", healthHandler)
+	`
+	exact, prefix := extractRoutes(src)
+
+	wantExact := []string{"/api/v1/auth/login", "/api/v1/communities"}
+	wantPrefix := []string{"/api/v1/communities/"}
+
+	if got := keys(exact); !reflect.DeepEqual(got, wantExact) {
+		t.Errorf("exact routes mismatch: got %v want %v", got, wantExact)
+	}
+	if got := keys(prefix); !reflect.DeepEqual(got, wantPrefix) {
+		t.Errorf("prefix routes mismatch: got %v want %v", got, wantPrefix)
+	}
+}
+
+func TestExtractDocumentedPaths(t *testing.T) {
+	docs := map[string]string{
+		"README.md": "| GET | `/api/v1/regions/:id` | get region |",
+		"CLAUDE.md": "see `/api/v1/auth/login` and `/api/v1/schools/{id}/join`",
+	}
+	got := extractDocumentedPaths(docs)
+	want := map[string]struct{}{
+		"/api/v1/regions/:id":       {},
+		"/api/v1/auth/login":        {},
+		"/api/v1/schools/:id/join":  {},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("documented paths mismatch:\n got %v\nwant %v", keys(got), keys(want))
+	}
+}
+
+func TestNormalizeDocPath(t *testing.T) {
+	cases := map[string]string{
+		"/api/v1/foo/:id":          "/api/v1/foo/:id",
+		"/api/v1/foo/{id}":         "/api/v1/foo/:id",
+		"/api/v1/foo/{user_id}":    "/api/v1/foo/:id",
+		"/api/v1/foo/:user_id":     "/api/v1/foo/:id",
+		"/api/v1/foo/":             "/api/v1/foo",
+		"/api/v1/foo,":             "/api/v1/foo",
+	}
+	for in, want := range cases {
+		if got := normalizeDocPath(in); got != want {
+			t.Errorf("normalizeDocPath(%q) = %q want %q", in, got, want)
+		}
+	}
+}
+
+func TestDiffEndpoints_PrefixCoversSubPath(t *testing.T) {
+	realExact := map[string]struct{}{"/api/v1/schools": {}}
+	realPrefix := map[string]struct{}{"/api/v1/schools/": {}}
+	doc := map[string]struct{}{
+		"/api/v1/schools":         {},
+		"/api/v1/schools/:id":     {}, // covered by prefix
+		"/api/v1/schools/:id/foo": {}, // covered by prefix
+	}
+	r := diffEndpoints(realExact, realPrefix, doc)
+	if len(r.documentedButMissing) != 0 {
+		t.Errorf("expected no documented-but-missing, got %v", r.documentedButMissing)
+	}
+	if len(r.realButUndocumented) != 0 {
+		t.Errorf("expected no real-but-undocumented, got %v", r.realButUndocumented)
+	}
+}
+
+func TestDiffEndpoints_FlagsRenameDrift(t *testing.T) {
+	// Simulates the regions→communities rename: docs still say "regions",
+	// router actually serves "communities".
+	realExact := map[string]struct{}{"/api/v1/communities": {}}
+	realPrefix := map[string]struct{}{"/api/v1/communities/": {}}
+	doc := map[string]struct{}{
+		"/api/v1/regions":     {},
+		"/api/v1/regions/:id": {},
+	}
+	r := diffEndpoints(realExact, realPrefix, doc)
+	if got := r.documentedButMissing; !reflect.DeepEqual(got, []string{"/api/v1/regions", "/api/v1/regions/:id"}) {
+		t.Errorf("documented-but-missing mismatch: got %v", got)
+	}
+	wantUndoc := []string{"/api/v1/communities", "/api/v1/communities/:id"}
+	if got := r.realButUndocumented; !reflect.DeepEqual(got, wantUndoc) {
+		t.Errorf("real-but-undocumented mismatch: got %v want %v", got, wantUndoc)
+	}
+}
+
+func TestExtractRealTables_CreateDropRename(t *testing.T) {
+	migrations := []string{
+		"CREATE TABLE IF NOT EXISTS users (id INT);",
+		"CREATE TABLE blacklist_proposals (id INT);\nCREATE TABLE blacklist_votes (id INT);",
+		// later migration renames + drops
+		"RENAME TABLE blacklist_proposals TO blocklist_proposals;\nDROP TABLE blacklist_votes;",
+		"ALTER TABLE users RENAME TO accounts;",
+	}
+	real := extractRealTables(migrations)
+	got := keys(real)
+	want := []string{"accounts", "blocklist_proposals"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("real tables mismatch: got %v want %v", got, want)
+	}
+}
+
+func TestExtractDocumentedTables(t *testing.T) {
+	docs := map[string]string{
+		"CLAUDE.md": "Key tables: `users`, `geographic_regions`, `blacklist_proposals`, `vouches`",
+		"DESIGN.md": "see `users` column descriptions", // not under Key tables, ignored
+	}
+	got := extractDocumentedTables(docs)
+	want := map[string]struct{}{
+		"users":               {},
+		"geographic_regions":  {},
+		"blacklist_proposals": {},
+		"vouches":             {},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("documented tables mismatch:\n got %v\nwant %v", keys(got), keys(want))
+	}
+}
+
+func TestDiffTables_DetectsRenameDrift(t *testing.T) {
+	// Docs still list the pre-rename names; code reflects post-rename.
+	real := map[string]struct{}{
+		"users":                {},
+		"blocklist_proposals":  {},
+		"meshtastic_channels":  {},
+		"schema_migrations":    {}, // ignored
+	}
+	doc := map[string]struct{}{
+		"users":               {},
+		"blacklist_proposals": {},
+	}
+	r := diffTables(real, doc)
+	if got := r.documentedButMissing; !reflect.DeepEqual(got, []string{"blacklist_proposals"}) {
+		t.Errorf("documented-but-missing mismatch: got %v", got)
+	}
+	wantUndoc := []string{"blocklist_proposals", "meshtastic_channels"}
+	if got := r.realButUndocumented; !reflect.DeepEqual(got, wantUndoc) {
+		t.Errorf("real-but-undocumented mismatch: got %v want %v", got, wantUndoc)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -495,6 +495,10 @@ tidy:
     @echo "🧹 Tidying modules..."
     go mod tidy
 
+# Detect drift between prose docs (CLAUDE.md/DESIGN.md/README.md) and the real code/schema
+doc-drift *ARGS:
+    @go run ./cmd/doc-drift {{ARGS}}
+
 # Run security scanners (gosec + govulncheck)
 security:
     @echo "🔒 Running security scanners..."


### PR DESCRIPTION
## Summary

Adds `cmd/doc-drift`, a small Go CLI that surfaces drift between the repo's prose docs (`CLAUDE.md`, `DESIGN.md`, `README.md`) and the real codebase. Two checks, deliberately narrow:

1. **API endpoints** documented in markdown vs. routes registered in `internal/handlers/router.go`. Handles `http.ServeMux` prefix routes (trailing-slash registrations) and normalizes `:id` / `{id}` / `:user_id` so doc and code paths can be compared.
2. **Database tables** documented in the `Key tables:` line of `CLAUDE.md` vs. the resulting schema after replaying `migrations/*.up.sql` in order (`CREATE TABLE` / `DROP TABLE` / `RENAME TABLE` / `ALTER TABLE ... RENAME TO`), so renamed tables (e.g. `blacklist_*` → `blocklist_*`) are tracked correctly.

Each check reports `documented-but-missing` and `real-but-undocumented` items, and exits non-zero when drift is found (`--warn-only` softens for CI). Exposed via `just doc-drift`.

This PR only adds the detector. The drift it surfaces is **not** fixed here so reviewers can audit detector output separately from doc edits — that's a follow-up.

## What the detector currently reports

Running `just doc-drift` against `main` (+ this branch) finds real drift that confirms the tool works:

### Tables — `blacklist` → `blocklist` rename never propagated to docs
- documented-but-missing: `blacklist_proposals`, `blacklist_votes`, `blacklisted_users`, `invite_link_update_proposals`, `invite_link_update_votes`
- real-but-undocumented: `blocklist_proposals`, `blocklist_votes`, `blocked_users`, `blocked_addresses`, `meshtastic_channels`, `encrypted_secrets`, `encrypted_secret_keys`, `secret_update_proposals`, `secret_update_votes`, `proposal_wrapped_keys`, `user_encryption_keys`, `user_reports`, `password_reset_tokens`, `rate_limits`, `admin_boundaries`

### Endpoints — `regions` → `communities` rename never propagated to docs
- documented-but-missing: `/api/v1/regions`, `/api/v1/regions/:id`, `/api/v1/regions/:id/invitations`, `/api/v1/regions/:id/membership-requests`
- real-but-undocumented (highlights): `/api/v1/communities`, `/api/v1/communities/:id`, `/api/v1/communities/admin`, `/api/v1/blocklist-proposals(/:id)`, `/api/v1/encryption/*`, `/api/v1/meshtastic-channels(/:id)`, `/api/v1/reports(/:id)`, `/api/v1/secret-proposals(/:id)`, `/api/v1/auth/{forgot,reset,change,validate-reset,verify-email,resend-verification}-*`, `/api/v1/users/me/deletion-preflight`

These all look like genuine doc-staleness, not detector bugs.

## Test plan

- [x] `go test ./cmd/doc-drift/...` — unit tests cover the route extractor, doc-path extractor, normalization, prefix-route matching, the `regions`→`communities` rename scenario, and the migration replay (`CREATE` / `DROP` / `RENAME` / `ALTER ... RENAME TO`).
- [x] `go run ./cmd/doc-drift` against the live repo prints the lists above and exits non-zero.
- [x] `go run ./cmd/doc-drift --warn-only` exits 0 with the same output.
- [ ] (follow-up PR) update `CLAUDE.md`, `DESIGN.md`, and `README.md` to fix the surfaced drift, then re-run `just doc-drift` and confirm it exits clean.