### PR TITLE
docs: backfill CONTRIBUTING, SECURITY, and docs/ entry-point guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to Community Rapid Response
+
+Thanks for your interest in contributing. This guide covers how to set up a local
+development environment, run tests, and submit changes. For project background and
+high-level architecture, see [README.md](README.md) and [DESIGN.md](DESIGN.md).
+
+## Prerequisites
+
+- [Go](https://golang.org/dl/) 1.25.9 (matches `go.mod`)
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+- [just](https://github.com/casey/just) command runner
+- Git
+
+Optional but recommended:
+- [air](https://github.com/air-verse/air) for hot reload (`just dev-local` will install it on demand)
+- A Mapbox account and a Postgrid/Lob account for end-to-end verification flows
+
+## Local Setup
+
+```bash
+git clone https://github.com/opencrr/communityrapidresponse.net.git
+cd communityrapidresponse.net
+
+# First-time setup: copies .env.example to .env, installs Go deps,
+# and starts the MariaDB container.
+just init
+
+# Start the development server with hot reload (in Docker).
+just dev
+```
+
+The HTTP API listens on `http://localhost:8080`. See [README.md](README.md#environment-variables)
+for the full list of environment variables and [.env.example](.env.example) for sane
+defaults.
+
+### Database Migrations
+
+Migrations are idempotent and tracked in the `schema_migrations` table. Each migration
+is a paired `NNN_description.up.sql` / `NNN_description.down.sql` file under
+[`migrations/`](migrations/).
+
+```bash
+just db-migrate           # apply pending migrations to the dev database
+just db-migrate test      # apply to the test database
+just db-migrate-status    # show applied/pending migrations
+just db-migrate-down 1    # roll back the most recent migration
+```
+
+When changing the schema, add a new pair of migration files; do not edit applied ones.
+
+### Seeding Schools
+
+NCES school data is bulk-loaded via a separate command:
+
+```bash
+just seed-schools         # or `go run ./cmd/seed-schools`
+```
+
+## Running Tests
+
+Tests are designed to run inside Docker so they share the dev database setup.
+
+```bash
+just test                 # full test suite
+just test-unit            # unit tests only (no database)
+just test-integration     # integration tests
+just test-handlers        # HTTP handler tests
+just test-db              # database/repository tests
+just test-coverage        # generate a coverage report
+just test-run TestName    # run a single test by name
+```
+
+If you change handler or service behavior, add or update the corresponding tests
+under `internal/handlers/*_test.go`, `internal/services/*_test.go`, or `tests/`.
+
+## Code Style
+
+- Run `just fmt` before committing — it wraps `gofmt`/`goimports`.
+- Run `just lint` — it invokes `golangci-lint` using the rules in [`.golangci.yml`](.golangci.yml).
+- Keep packages small and focused. Internal layout:
+  - `cmd/`        — binaries (`server`, `seed-schools`)
+  - `internal/config`        — env-driven configuration
+  - `internal/database`      — repositories and DB connection
+  - `internal/handlers`      — HTTP handlers and routing
+  - `internal/middleware`    — auth, rate-limit, CORS, CSRF, security headers
+  - `internal/models`        — domain types
+  - `internal/services`      — external integrations (Mapbox, Postgrid/Lob, SendGrid, SMTP, MFA)
+  - `internal/logging`, `internal/sentry` — observability
+- Match the existing error style — handlers should produce structured JSON errors via the
+  shared helpers in `internal/handlers/helpers.go`.
+
+## Branching, Commits, and Pull Requests
+
+1. Branch off `main`. Use descriptive branch names, for example:
+   - `feat/<topic>` for new features
+   - `fix/<topic>` for bug fixes
+   - `docs/<topic>` for documentation
+   - `chore/<topic>` for tooling, deps, refactors
+2. Keep commits focused and write a short, imperative subject line. Reference an
+   issue or PR number where helpful.
+3. Run `just fmt`, `just lint`, and `just test` locally before pushing.
+4. Open a pull request against `main` with:
+   - A summary of the change and its motivation.
+   - Notes on schema changes, breaking changes, or new env vars.
+   - A test plan (commands run, scenarios exercised).
+5. Address review feedback in additional commits — squash on merge.
+
+## Privacy and Security Expectations
+
+This project takes a hard line on address storage: addresses are processed in memory
+only and never written to the database. When contributing code that touches
+verification, geocoding, or mailing flows, do not introduce persistence of street
+addresses, apartment numbers, or precise GPS coordinates. See [SECURITY.md](SECURITY.md)
+for the responsible disclosure process and the full security posture.
+
+## Useful Documentation
+
+- [README.md](README.md) — project overview, quick start, API summary
+- [DESIGN.md](DESIGN.md) — authoritative design spec
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system architecture overview
+- [docs/API.md](docs/API.md) — REST API reference
+- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) — deployment and operations
+- [CLAUDE.md](CLAUDE.md) — quick-reference for AI assistants

--- a/README.md
+++ b/README.md
@@ -409,9 +409,23 @@ curl -X POST http://localhost:8080/api/v1/mfa/verify \
 
 ## Deployment
 
-Deployment infrastructure is maintained in a separate repository. See the deployment repo for provisioning, configuration management, and CI/CD workflows.
+Deployment infrastructure is maintained in a separate repository. See the deployment repo for provisioning, configuration management, and CI/CD workflows. For application-level deploy steps, env vars, and the production checklist, see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+
+## Documentation
+
+Supplementary documentation lives at the repo root and under [`docs/`](docs/):
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — local setup, testing, code style, PR workflow
+- [SECURITY.md](SECURITY.md) — responsible disclosure policy and security posture
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system architecture overview
+- [docs/API.md](docs/API.md) — REST API reference
+- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) — deployment and operations guide
+- [DESIGN.md](DESIGN.md) — authoritative design specification
+- [CLAUDE.md](CLAUDE.md) — quick reference for AI assistants
 
 ## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow (prerequisites, local setup, testing, code style, branching, and PR conventions). The short version:
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,101 @@
+# Security Policy
+
+Community Rapid Response exists to help people connect with verified neighbors. The
+trust that powers that experience depends on us holding a high security and privacy
+bar. We welcome reports of vulnerabilities and concerns from the security community.
+
+## Supported Versions
+
+This project is actively developed against the `main` branch. Security fixes are
+applied to `main` and rolled out via the most recent tagged release. Older releases
+do not receive backports unless explicitly noted. Always run a build from a recent
+`main` or release tag.
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for suspected vulnerabilities.** Instead,
+report privately via one of the following channels:
+
+- GitHub Security Advisory: <https://github.com/opencrr/communityrapidresponse.net/security/advisories/new>
+  (use "Report a vulnerability" — this keeps the report private to maintainers).
+- Email: `security@communityrapidresponse.net`. Encrypt sensitive material if possible.
+
+Include:
+
+- A description of the issue and the impact you believe it has.
+- Steps to reproduce, including affected endpoint(s), payload(s), and any
+  authentication state required.
+- Your name or handle for credit (optional) and how you would like to be acknowledged.
+
+### Response Targets
+
+- **Acknowledgement**: within 3 business days of receipt.
+- **Triage and severity assessment**: within 7 business days.
+- **Fix or mitigation plan**: communicated within 30 days for high/critical issues.
+
+We will keep you informed throughout the process and credit reporters who request it
+once a fix has shipped.
+
+## Scope
+
+The following are in scope:
+
+- The Go backend in this repository (handlers, middleware, services).
+- The database schema, migrations, and data-handling logic.
+- The static frontend assets under [`static/`](static/) and [`templates/`](templates/)
+  that ship with the backend.
+
+The following are explicitly **out of scope**:
+
+- Third-party providers we integrate with (Mapbox, Postgrid/Lob, SendGrid, Signal).
+  Please report issues there to the upstream vendor.
+- Denial-of-service attacks, volumetric attacks, or social engineering against
+  maintainers or users.
+- Issues that require physical access to a user's device, root access to the host,
+  or compromised user credentials obtained outside this system.
+- Findings that depend on disabled-by-default development flags such as
+  `MFA_REQUIRED=false` or `RATE_LIMIT_ENABLED=false`. Production deployments are
+  expected to enable both.
+
+## Security Posture
+
+This is a short summary of the controls in place. See [DESIGN.md](DESIGN.md) and
+[CLAUDE.md](CLAUDE.md) for full detail.
+
+- **Zero address storage**: Street addresses, apartment numbers, and precise GPS
+  coordinates are never persisted. Addresses live in memory only for the lifetime
+  of a verification request, are sent to the mailing provider (Postgrid/Lob), and
+  are then discarded.
+- **MFA**: TOTP-based MFA is mandatory in production. MFA secrets are encrypted
+  with AES-256-GCM before being written to the database.
+- **Token model**: JWT tokens are issued for distinct purposes (`full`,
+  `mfa_setup`, `pending_mfa`, `email_unverified`) so a token issued for one
+  purpose cannot be replayed against another. Full tokens expire in 24 hours;
+  intermediate tokens expire in 10 minutes.
+- **Cookies**: Tokens are stored in HttpOnly cookies. Production deployments set
+  `SECURE_COOKIES=true` (requires HTTPS).
+- **Password storage**: bcrypt at cost factor 12, minimum 12-character passwords.
+- **Account lockout**: 10 failed login attempts trigger a 15-minute lock; locks
+  are audit-logged.
+- **Rate limiting**: Per-IP global limits plus tighter limits on `login`,
+  `register`, `forgot-password`, `reset-password`, and `resend-verification`.
+  Verification (3/30d) and vouches (10/month) are also rate-limited.
+- **Address validation**: Postgrid/Lob rejects PO Boxes and CMRA addresses; only
+  residential/business street addresses are accepted.
+- **Email content**: Sensitive material (invite links, verification codes,
+  addresses) is **never** included in emails. Notifications instruct users to log
+  in to view sensitive details.
+- **Encryption at rest**: Production deployments enable MariaDB data-at-rest
+  encryption (or filesystem-level encryption). See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+- **Consensus governance**: Deletions, user blocklisting, and Signal/Meshtastic
+  invite/secret updates require 3-admin approval to limit unilateral abuse.
+- **Audit logging**: All administrative actions are written to an audit log with
+  a 90-day retention.
+
+## Coordinated Disclosure
+
+We support coordinated disclosure. Once a fix has been released and deployed, we
+will publish a security advisory describing the issue, affected versions, and the
+mitigation. Reporters who request credit will be named in the advisory.
+
+Thank you for helping keep Community Rapid Response and its users safe.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,277 @@
+# REST API Reference
+
+The Community Rapid Response API is a JSON-over-HTTPS API. This document is a
+reference for the endpoints surfaced by [`internal/handlers/router.go`](../internal/handlers/router.go).
+For example payloads and request flows, see [DESIGN.md](../DESIGN.md). For a higher
+level overview of the system, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+All endpoints are versioned under `/api/v1/`.
+
+## Authentication
+
+Authentication is JWT-based. On successful login the API issues a token of one of
+the following types:
+
+| Token type           | Lifetime  | Used for                                         |
+|----------------------|-----------|--------------------------------------------------|
+| `full`               | 24 hours  | All authenticated endpoints                      |
+| `mfa_setup`          | 10 minutes| `/api/v1/mfa/setup`, `/api/v1/mfa/setup/complete`|
+| `pending_mfa`        | 10 minutes| `/api/v1/mfa/verify`                             |
+| `email_unverified`   | 10 minutes| `/api/v1/auth/resend-verification`               |
+
+Tokens may be supplied either as:
+
+- An `Authorization: Bearer <token>` header, or
+- An HttpOnly cookie (set automatically by the API on login).
+
+A token of the wrong type for an endpoint is rejected with `401 Unauthorized`.
+
+### CSRF and CORS
+
+- CORS allowed origins are configured via `CORS_ALLOWED_ORIGINS`.
+- CSRF protection is enabled when `CSRF_ENABLED=true`. State-changing requests
+  (`POST`/`PUT`/`PATCH`/`DELETE`) require a CSRF token issued via the standard
+  double-submit cookie pattern.
+
+### Rate Limiting
+
+Global per-IP rate limiting is applied when `RATE_LIMIT_ENABLED=true` (default
+100 req/min/IP). Auth endpoints have tighter, dedicated limits:
+
+| Endpoint                              | Limit              |
+|---------------------------------------|--------------------|
+| `POST /api/v1/auth/login`             | 10 / 5 min / IP    |
+| `POST /api/v1/auth/register`          | 3 / hr / IP        |
+| `POST /api/v1/auth/forgot-password`   | 5 / 15 min / IP    |
+| `POST /api/v1/auth/reset-password`    | 10 / 15 min / IP   |
+| `POST /api/v1/auth/resend-verification` | 3 / 15 min / IP  |
+
+Application-level rate limits also apply to verification (3/30d/user), vouches
+(10/month/user), and blocklist proposals (5/month/user).
+
+## Endpoint Index
+
+### Health
+
+| Method | Path                  | Auth | Notes                  |
+|--------|-----------------------|------|------------------------|
+| GET    | `/health`             | none | Health check           |
+| GET    | `/api/v1/health`      | none | Health check (aliased) |
+
+### Auth
+
+| Method | Path                                          | Auth              | Notes                                                |
+|--------|-----------------------------------------------|-------------------|------------------------------------------------------|
+| POST   | `/api/v1/auth/register`                       | none              | Create account                                       |
+| POST   | `/api/v1/auth/login`                          | none              | Returns `full`, `mfa_setup`, or `pending_mfa` token  |
+| POST   | `/api/v1/auth/logout`                         | none              | Clears auth cookie                                   |
+| GET    | `/api/v1/auth/verify-email`                   | none              | Verify email via emailed link                        |
+| POST   | `/api/v1/auth/forgot-password`                | none              | Initiate password reset                              |
+| POST   | `/api/v1/auth/reset-password`                 | none              | Complete password reset                              |
+| GET    | `/api/v1/auth/validate-reset-token`           | none              | Check whether a reset token is still valid           |
+| POST   | `/api/v1/auth/change-password`                | `full`            | Change password while logged in                      |
+| POST   | `/api/v1/auth/resend-verification`            | `email_unverified`| Resend verification email                            |
+
+### MFA
+
+| Method | Path                                | Auth          | Notes                                              |
+|--------|-------------------------------------|---------------|----------------------------------------------------|
+| POST   | `/api/v1/mfa/setup`                 | `mfa_setup`   | Returns QR code + provisioning URI                 |
+| POST   | `/api/v1/mfa/setup/complete`        | `mfa_setup`   | Confirms TOTP code, returns backup codes + `full`  |
+| POST   | `/api/v1/mfa/verify`                | `pending_mfa` | Verifies TOTP or backup code, returns `full` token |
+
+### Current User
+
+| Method | Path                                          | Auth   | Notes                                |
+|--------|-----------------------------------------------|--------|--------------------------------------|
+| GET    | `/api/v1/users/me`                            | `full` | Get current user                     |
+| DELETE | `/api/v1/users/me`                            | `full` | Delete own account                   |
+| GET    | `/api/v1/users/me/deletion-preflight`         | `full` | Check what cascades on delete        |
+
+### Verification
+
+| Method | Path                                          | Auth   | Notes                                          |
+|--------|-----------------------------------------------|--------|------------------------------------------------|
+| GET    | `/api/v1/verification/status`                 | `full` | Postcard + vouch status                        |
+| POST   | `/api/v1/verification/postcard/request`       | `full` | Submit address; address is never stored        |
+| POST   | `/api/v1/verification/postcard/verify`        | `full` | Submit one-time postcard code                  |
+| POST   | `/api/v1/verification/vouch/request`          | `full` | Open a vouch request for the current user      |
+| POST   | `/api/v1/verification/vouch`                  | `full` | Vouch for another user                         |
+| GET    | `/api/v1/verification/vouch/pending`          | `full` | List pending vouch requests for current user   |
+| GET    | `/api/v1/verification/vouch/status/:user_id`  | `full` | Get vouch status for a target user             |
+
+### Regions (Communities)
+
+Note: the public API uses `/api/v1/communities/...`. Internally these are called
+"regions" and back the same data model.
+
+| Method | Path                                                   | Auth   | Notes                                       |
+|--------|--------------------------------------------------------|--------|---------------------------------------------|
+| GET    | `/api/v1/communities`                                  | `full` | List regions scoped to user membership      |
+| POST   | `/api/v1/communities`                                  | `full` | Create region (admin)                       |
+| GET    | `/api/v1/communities/admin`                            | `full` | List regions the user administers           |
+| GET    | `/api/v1/communities/:id`                              | `full` | Region detail + sub-regions via `ST_Contains` |
+| PUT    | `/api/v1/communities/:id`                              | `full` | Rename (admin/superuser)                    |
+| DELETE | `/api/v1/communities/:id`                              | `full` | Cascade delete (superuser only)             |
+| GET    | `/api/v1/communities/:id/members`                      | `full` | Members (email-stripped)                    |
+| GET    | `/api/v1/communities/:id/users`                        | `full` | Member detail for admins                    |
+| POST   | `/api/v1/communities/:id/membership-requests`          | `full` | Request to join                             |
+| GET    | `/api/v1/communities/:id/membership-requests`          | `full` | List pending requests (admin)               |
+| POST   | `/api/v1/communities/:id/invitations`                  | `full` | Invite user (admin)                         |
+| POST   | `/api/v1/communities/:id/blocklist-proposals`          | `full` | Open blocklist proposal (≥3 admins required)|
+| POST   | `/api/v1/communities/:id/reports`                      | `full` | Report user (scope = region)                |
+
+### Membership Requests
+
+| Method | Path                                              | Auth   | Notes                          |
+|--------|---------------------------------------------------|--------|--------------------------------|
+| GET    | `/api/v1/membership-requests`                     | `full` | List own requests              |
+| GET    | `/api/v1/membership-requests/admin`               | `full` | List all pending (admin view)  |
+| GET    | `/api/v1/membership-requests/:id`                 | `full` | Detail                         |
+| DELETE | `/api/v1/membership-requests/:id`                 | `full` | Cancel                         |
+| POST   | `/api/v1/membership-requests/:id/vote`            | `full` | Vote (≥2 approvals to accept)  |
+
+### Invitations
+
+| Method | Path                                         | Auth   | Notes                |
+|--------|----------------------------------------------|--------|----------------------|
+| GET    | `/api/v1/invitations`                        | `full` | List own invitations |
+| POST   | `/api/v1/invitations/:id/respond`            | `full` | Accept or decline    |
+
+### Signal Groups
+
+A Signal group belongs to exactly one of a region, a school, or a school district
+(three-way XOR).
+
+| Method | Path                                              | Auth   | Notes                                |
+|--------|---------------------------------------------------|--------|--------------------------------------|
+| GET    | `/api/v1/signal-groups`                           | `full` | List visible Signal groups           |
+| POST   | `/api/v1/signal-groups`                           | `full` | Create (admin)                       |
+| GET    | `/api/v1/signal-groups/admin`                     | `full` | Groups the user administers          |
+| PUT    | `/api/v1/signal-groups/:id`                       | `full` | Update group metadata                |
+| POST   | `/api/v1/signal-groups/:id/secret-proposals`      | `full` | Propose a new invite link/secret     |
+
+### Secret-Update Proposals (Invite Links, etc.)
+
+3-admin consensus, with end-to-end encrypted secret payloads finalized after
+approval.
+
+| Method | Path                                                | Auth   | Notes                                 |
+|--------|-----------------------------------------------------|--------|---------------------------------------|
+| GET    | `/api/v1/secret-proposals`                          | `full` | List proposals visible to the user    |
+| GET    | `/api/v1/secret-proposals/:id`                      | `full` | Proposal detail                       |
+| POST   | `/api/v1/secret-proposals/:id/vote`                 | `full` | Vote on a proposal                    |
+| POST   | `/api/v1/secret-proposals/:id/expire`               | `full` | Manually expire (superuser only)      |
+| POST   | `/api/v1/encrypted-secrets/:id/finalize`            | `full` | Finalize an encrypted secret payload  |
+
+### Encryption (E2E Key Management)
+
+| Method | Path                                              | Auth   | Notes                                  |
+|--------|---------------------------------------------------|--------|----------------------------------------|
+| GET    | `/api/v1/encryption/keys`                         | `full` | Retrieve user key material             |
+| POST   | `/api/v1/encryption/keys`                         | `full` | Upload key material                    |
+| PUT    | `/api/v1/encryption/keys`                         | `full` | Update key material                    |
+| POST   | `/api/v1/encryption/keys/rotate`                  | `full` | Rotate user keys                       |
+| GET    | `/api/v1/encryption/public-keys`                  | `full` | Lookup public keys for a set of users  |
+| GET    | `/api/v1/encryption/pending-rekeys`                | `full` | List pending rekey requests            |
+| POST   | `/api/v1/encryption/rekey`                        | `full` | Submit rekey payloads                  |
+
+### Deletion Proposals (Consensus Delete)
+
+| Method | Path                                              | Auth   | Notes              |
+|--------|---------------------------------------------------|--------|--------------------|
+| GET    | `/api/v1/deletion-proposals`                      | `full` | List proposals     |
+| POST   | `/api/v1/deletion-proposals`                      | `full` | Create proposal    |
+| GET    | `/api/v1/deletion-proposals/:id`                  | `full` | Proposal detail    |
+| POST   | `/api/v1/deletion-proposals/:id/vote`             | `full` | Vote               |
+| POST   | `/api/v1/deletion-proposals/:id/expire`           | `full` | Force-expire       |
+
+### Blocklist Proposals
+
+| Method | Path                                              | Auth   | Notes                          |
+|--------|---------------------------------------------------|--------|--------------------------------|
+| GET    | `/api/v1/blocklist-proposals`                     | `full` | List proposals                 |
+| GET    | `/api/v1/blocklist-proposals/:id`                 | `full` | Detail                         |
+| POST   | `/api/v1/blocklist-proposals/:id/vote`            | `full` | Vote                           |
+| POST   | `/api/v1/blocklist-proposals/:id/expire`          | `full` | Force-expire (superuser only)  |
+
+### User Reports
+
+| Method | Path                                              | Auth   | Notes                       |
+|--------|---------------------------------------------------|--------|-----------------------------|
+| GET    | `/api/v1/reports`                                 | `full` | List reports                |
+| GET    | `/api/v1/reports/:id`                             | `full` | Detail                      |
+| POST   | `/api/v1/reports/:id/resolve`                     | `full` | Resolve report              |
+
+### Schools
+
+| Method | Path                                                  | Auth   | Notes                                |
+|--------|-------------------------------------------------------|--------|--------------------------------------|
+| GET    | `/api/v1/schools`                                     | `full` | Search by name/state                 |
+| GET    | `/api/v1/schools/my`                                  | `full` | List user's schools                  |
+| GET    | `/api/v1/schools/:id`                                 | `full` | School detail                        |
+| POST   | `/api/v1/schools/:id/join`                            | `full` | Join (pending membership)            |
+| POST   | `/api/v1/schools/:id/leave`                           | `full` | Leave                                |
+| POST   | `/api/v1/schools/:id/vouch`                           | `full` | Vouch for a school member            |
+| GET    | `/api/v1/schools/:id/vouch/pending`                   | `full` | List pending vouch requests          |
+| GET    | `/api/v1/schools/:id/vouch-status/:user_id`           | `full` | Get vouch status for a user          |
+| GET    | `/api/v1/schools/:id/members`                         | `full` | List members                         |
+| GET    | `/api/v1/schools/:id/signal-groups`                   | `full` | List school Signal groups            |
+| POST   | `/api/v1/schools/:id/signal-groups`                   | `full` | Create (school admin)                |
+| POST   | `/api/v1/schools/:id/reports`                         | `full` | Report user (scope = school)         |
+
+### School Districts
+
+| Method | Path                                                       | Auth   | Notes                              |
+|--------|------------------------------------------------------------|--------|------------------------------------|
+| GET    | `/api/v1/school-districts`                                 | `full` | Search                             |
+| GET    | `/api/v1/school-districts/:id`                             | `full` | Detail                             |
+| GET    | `/api/v1/school-districts/:id/members`                     | `full` | District-level members             |
+| GET    | `/api/v1/school-districts/:id/signal-groups`               | `full` | List district Signal groups        |
+| POST   | `/api/v1/school-districts/:id/signal-groups`               | `full` | Create (district admin)            |
+| POST   | `/api/v1/school-districts/:id/reports`                     | `full` | Report user (scope = district)     |
+
+### Meshtastic Channels
+
+Same shape as Signal groups, with three-way XOR ownership.
+
+| Method | Path                                                       | Auth   | Notes                                 |
+|--------|------------------------------------------------------------|--------|---------------------------------------|
+| GET    | `/api/v1/meshtastic-channels`                              | `full` | List                                  |
+| POST   | `/api/v1/meshtastic-channels`                              | `full` | Create                                |
+| GET    | `/api/v1/meshtastic-channels/admin`                        | `full` | Channels the user administers         |
+| PUT    | `/api/v1/meshtastic-channels/:id`                          | `full` | Update                                |
+| POST   | `/api/v1/meshtastic-channels/:id/secret-proposals`         | `full` | Propose a new channel secret          |
+
+### Admin (Superuser)
+
+| Method | Path                                                  | Auth   | Notes                              |
+|--------|-------------------------------------------------------|--------|------------------------------------|
+| GET    | `/api/v1/admin/users`                                 | `full` | Search users                       |
+| GET    | `/api/v1/admin/users/:id`                             | `full` | Get user                           |
+| DELETE | `/api/v1/admin/users/:id`                             | `full` | Delete user                        |
+| POST   | `/api/v1/admin/users/:id/grant-vouch`                 | `full` | Grant vouch verification           |
+| POST   | `/api/v1/admin/users/:id/revoke-vouch`                | `full` | Revoke vouch verification          |
+| POST   | `/api/v1/admin/users/:id/block`                       | `full` | Block user                         |
+| POST   | `/api/v1/admin/users/:id/unblock`                     | `full` | Unblock user                       |
+| GET    | `/api/v1/admin/audit-logs`                            | `full` | List audit log entries             |
+| GET    | `/api/v1/admin/audit-logs/export`                     | `full` | Export audit log as CSV/JSON       |
+| GET    | `/api/v1/admin/blocked-addresses`                     | `full` | List blocked address hashes        |
+| POST   | `/api/v1/admin/blocked-addresses/:hash/expire`        | `full` | Expire a blocked address hash      |
+
+## Errors
+
+Errors are returned as JSON of the shape:
+
+```json
+{ "code": "snake_case_code", "message": "Human readable description" }
+```
+
+Standard error codes include `unauthorized`, `forbidden`, `not_found`,
+`invalid_id`, `missing_id`, `method_not_allowed`, `rate_limited`, `validation_failed`.
+
+## Source of Truth
+
+The router is the canonical list of endpoints. If this document diverges, trust
+[`internal/handlers/router.go`](../internal/handlers/router.go). DESIGN.md is the
+canonical source for request/response payload shapes and business rules.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,190 @@
+# Architecture Overview
+
+This document is a concise, pointer-style summary of how Community Rapid Response is
+put together. For the full design — including database schema, API contracts, and
+implementation phases — see [DESIGN.md](../DESIGN.md). For day-to-day quick reference,
+see [CLAUDE.md](../CLAUDE.md).
+
+## Tech Stack
+
+| Layer        | Choice                                              |
+|--------------|-----------------------------------------------------|
+| Language     | Go 1.25.x                                           |
+| HTTP         | `net/http` standard library + custom `ServeMux`-based router |
+| Auth         | JWT (HS256) via `github.com/golang-jwt/jwt/v5`      |
+| MFA          | TOTP via `github.com/pquerna/otp`, AES-256-GCM at rest |
+| Database     | MariaDB 10.x with spatial extensions (`GEOMETRY SRID 4326`) |
+| Driver       | `github.com/go-sql-driver/mysql`                    |
+| Frontend     | Server-rendered HTML + vanilla JS (progressive enhancement) |
+| Mapping      | Mapbox GL JS, Mapbox Geocoding/Tile APIs, Mapbox Draw |
+| Address & mail | Postgrid or Lob (selected via `MAIL_PROVIDER`)    |
+| Email        | SendGrid, SMTP, or mock (selected via `EMAIL_BACKEND`) |
+| Observability| Sentry (`github.com/getsentry/sentry-go`), structured logs |
+| Build/Dev    | Docker Compose, [`justfile`](../justfile), `air` for hot reload |
+
+## Package Layout
+
+```
+cmd/
+  server/             # HTTP server entrypoint
+  seed-schools/       # one-shot NCES schools loader
+internal/
+  config/             # env-driven configuration
+  database/           # connection management and repositories
+  handlers/           # HTTP handlers + router.go
+  middleware/         # JWT auth, CORS, CSRF, rate-limit, security headers, recoverer
+  models/             # domain types
+  services/           # external integrations: mapbox, postgrid/lob, email, mfa, nces, ratelimit, notification
+  logging/            # structured logger
+  sentry/             # Sentry initialization
+  mocks/              # mock implementations for tests
+  testutil/           # shared test helpers
+migrations/           # NNN_description.up.sql / NNN_description.down.sql pairs
+tests/                # integration and end-to-end tests
+static/, templates/   # served frontend assets
+```
+
+The dependency direction is one-way: `cmd` → `handlers` → `services` + `database`
+→ `models`/`config`. Tests live alongside the package they exercise.
+
+## Request Lifecycle
+
+A request flows through the following middleware chain (outer to inner — see
+[`internal/handlers/router.go`](../internal/handlers/router.go)):
+
+```
+Logger → RequestContext → Sentry → Recoverer → RateLimit (optional) →
+CORS → SecurityHeaders → CSRF (optional) → MaxBodySize (1 MB) → ContentType → ServeMux
+```
+
+Handlers themselves wrap their `http.HandlerFunc` with one of the JWT auth helpers:
+
+- `authenticated` — requires a `full` token.
+- `authenticatedMFASetup` — requires an `mfa_setup` token.
+- `authenticatedPendingMFA` — requires a `pending_mfa` token.
+- `authenticatedEmailUnverified` — requires an `email_unverified` token.
+
+Per-token-type scoping means a token issued during MFA setup cannot be replayed
+against a protected resource endpoint and vice versa.
+
+## Core Domain Concepts
+
+### Verification Model
+
+Two independent verification paths, both required to become an admin:
+
+1. **Postcard verification** — physical mail through Postgrid/Lob to a real
+   address. Address is never persisted (see "Zero address storage" below). On
+   success, the user gains read-only access in their region.
+2. **Vouch verification** — two existing fully-verified users from a shared
+   geographic ancestor vouch for a new user. Bootstrap mode (when a region has
+   <3 admins) requires exact-region vouching.
+
+A user with **both** verifications becomes a region admin: they can create
+sub-regions, manage Signal groups, and vouch for others.
+
+A **superuser** flag (`is_superuser`) is set directly in the database and
+bypasses scoping for administrative tooling such as auditing, blocklists, and
+emergency vouch grants.
+
+### Geographic Hierarchy
+
+```
+State → County → City/Town → Locality (optional) → Neighborhood → City Block
+```
+
+- Regions are stored in `geographic_regions` with a nullable `GEOMETRY SRID 4326`
+  column. ~92% of neighborhoods and some localities have no polygon — they are
+  defined purely by `parent_id`.
+- Sub-region containment is resolved using a combination of:
+  - `ST_Contains` on regions with geometry, and
+  - `parent_id` traversal for the rest.
+- The spatial index on `geographic_regions.geometry` is intentionally disabled
+  due to a MariaDB Error 1207 incompatibility with `ST_Contains`. Containment
+  queries still work correctly without it.
+
+### Three-Way XOR for Signal Groups
+
+A Signal group belongs to **exactly one** of:
+
+- a region (`region_id`), or
+- a school (`school_id`), or
+- a school district (`district_id`).
+
+Enforced at the DB layer with a `CHECK` constraint. The same XOR shape applies
+to Meshtastic channels.
+
+### Consensus Governance
+
+Critical mutations require 3-admin approval. The shape is consistent across all
+proposals:
+
+| Action                    | Proposal table                    | Vote table                    |
+|---------------------------|-----------------------------------|-------------------------------|
+| Asset deletion            | `deletion_proposals`              | `deletion_votes`              |
+| Signal/Meshtastic secret update | `secret_update_proposals` (formerly `invite_link_update_proposals`) | `secret_update_votes` |
+| User blocklisting         | `blocklist_proposals`             | `blocklist_votes`             |
+| Sub-region join request   | `sub_region_membership_requests`  | `sub_region_membership_votes` |
+
+Blocklisting requires a region to have ≥3 admins. Proposals expire after 7 days.
+
+### Schools and School Districts
+
+Schools (sourced from NCES) and school districts run in parallel to regions:
+
+- Membership is vouch-based only (no postcard). Bootstrap mode (<3 verified
+  admins) requires 3 vouches; otherwise 2.
+- Both schools and districts can have their own Signal groups, scoped via the
+  three-way XOR.
+
+## Data Flow: Verification (Zero Address Storage)
+
+```
+[User] --address--> [API] -> [Postgrid/Lob validate]
+                             |--reject PO Box/CMRA
+                             v
+                       [Mapbox geocode]
+                             v
+                  [Extract hierarchy: state→county→city→locality→neighborhood]
+                             v
+       [Upsert geographic_regions (with or without geometry)]
+                             v
+       [Create pending user_regions entries at each level]
+                             v
+              [Postgrid/Lob mails postcard with one-time code]
+                             v
+              [Address dropped from memory — never written to DB]
+
+Later:
+[User submits code] --> [API verifies] --> [user_regions activated]
+```
+
+The DB never sees a street address. Only city/county/state names, region
+boundaries (from OpenStreetMap via Mapbox), and a Postgrid/Lob tracking ID are
+persisted.
+
+## Spatial Storage Notes
+
+- Geometries are stored as `GEOMETRY SRID 4326` (WGS84 lon/lat). Polygons come
+  from OSM via Mapbox; the application layer is responsible for ensuring valid
+  polygon orientation and closure.
+- All `ST_Contains` queries explicitly filter `WHERE geometry IS NOT NULL` so
+  geometry-less regions do not produce spurious matches.
+- UUIDs are `CHAR(36)` generated at the application layer (not via DB defaults)
+  to keep migrations portable.
+
+## Observability
+
+- **Logging**: structured request logs (method, path, status, latency, IP) are
+  emitted via `internal/logging`.
+- **Sentry**: errors and panics are forwarded via the Sentry HTTP middleware
+  when `SENTRY_DSN` is configured.
+- **Audit log**: administrative actions are recorded in the `audit_log` table
+  (90-day retention).
+
+## Further Reading
+
+- [DESIGN.md](../DESIGN.md) — full design specification.
+- [docs/API.md](API.md) — REST API reference.
+- [docs/DEPLOYMENT.md](DEPLOYMENT.md) — deployment, env vars, operations.
+- [CLAUDE.md](../CLAUDE.md) — quick reference for AI assistants.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,273 @@
+# Deployment Guide
+
+This guide covers running Community Rapid Response in a production-like environment.
+It complements the developer-oriented [README.md](../README.md) and
+[CONTRIBUTING.md](../CONTRIBUTING.md), and assumes you have already chosen and
+provisioned a host (cloud VPS, dedicated server, or managed container platform).
+
+Infrastructure provisioning (Terraform/Ansible) is maintained in a separate
+deployment repository; this document focuses on the application itself.
+
+## Topology
+
+A standard deployment runs four things:
+
+1. **Reverse proxy** (Nginx) — terminates TLS, serves static assets, proxies API
+   requests to the Go backend. See [`nginx.conf`](../nginx.conf) for the in-repo
+   reference config; production deployments typically extend it with TLS, HSTS,
+   and rate limiting at the edge.
+2. **Go backend** — the binary built from `cmd/server`. Listens on
+   `SERVER_HOST:SERVER_PORT` (defaults `0.0.0.0:8080`).
+3. **MariaDB 11.x** — with spatial extensions. The application schema is managed
+   via [`migrations/`](../migrations/).
+4. **Outbound integrations** — Mapbox (geocoding/tiles), Postgrid or Lob
+   (address validation + postcard mailing), SendGrid or SMTP (transactional
+   email), Sentry (errors).
+
+Optional:
+- A second MariaDB instance as a hot standby/replica.
+- A bastion or jump host for DB access.
+- A Meshtastic gateway (out of scope for this repo; the API only stores channel
+  metadata).
+
+## Build
+
+Production binaries are built via the multi-stage [`Dockerfile`](../Dockerfile).
+
+```bash
+just build-prod
+# or:
+docker build --target production -t communityrapidresponse:latest .
+```
+
+The resulting image runs `cmd/server` as PID 1 and exposes port 8080.
+
+## Configuration
+
+All configuration is environment-driven. The canonical list of variables lives in
+[`.env.example`](../.env.example) and is read by [`internal/config`](../internal/config).
+Below is the production-relevant subset.
+
+### Server
+
+| Variable        | Required | Example                | Notes                              |
+|-----------------|----------|------------------------|------------------------------------|
+| `SERVER_HOST`   | yes      | `0.0.0.0`              | Bind address                       |
+| `SERVER_PORT`   | yes      | `8080`                 | Bind port                          |
+| `ENVIRONMENT`   | yes      | `production`           | Used by logging/Sentry             |
+| `SECURE_COOKIES`| yes      | `true`                 | **Must be `true` in production**   |
+
+### Database
+
+| Variable        | Required | Example                                | Notes                                  |
+|-----------------|----------|----------------------------------------|----------------------------------------|
+| `DB_HOST`       | yes      | `db.internal`                          |                                        |
+| `DB_PORT`       | yes      | `3306`                                 |                                        |
+| `DB_USER`       | yes      | `communityrapidresponse`               | Use a least-privilege user             |
+| `DB_PASSWORD`   | yes      | (secret)                               | Provide via secret manager             |
+| `DB_NAME`       | yes      | `communityrapidresponse`               |                                        |
+
+Run migrations on every deploy:
+
+```bash
+just db-migrate                       # against the configured prod DB
+# or run inside the container:
+docker run --rm --env-file=prod.env communityrapidresponse:latest \
+  /app/scripts/migrate.sh up
+```
+
+### Authentication and MFA
+
+| Variable                | Required | Example                          | Notes                                              |
+|-------------------------|----------|----------------------------------|----------------------------------------------------|
+| `JWT_SECRET`            | yes      | 32+ char random string           | Rotate via deploy with rolling restart             |
+| `JWT_EXPIRATION_HOURS`  | yes      | `24`                             | Full-token lifetime                                |
+| `JWT_ISSUER`            | yes      | `communityrapidresponse`         |                                                    |
+| `MFA_REQUIRED`          | yes      | `true`                           | **Must be `true` in production**                   |
+| `MFA_ENCRYPTION_KEY`    | yes      | 32-byte key                      | AES-256-GCM key for TOTP secret encryption         |
+| `MFA_ISSUER`            | yes      | `Community Rapid Response`       | Shown in authenticator apps                        |
+
+### Mapbox
+
+| Variable               | Required | Notes                                  |
+|------------------------|----------|----------------------------------------|
+| `MAPBOX_PUBLIC_TOKEN`  | yes      | Exposed to the browser                 |
+| `MAPBOX_SECRET_TOKEN`  | yes      | Server-only; OSM lookups               |
+
+### Mail Provider (Address Validation + Postcards)
+
+Select via `MAIL_PROVIDER=lob` (recommended) or `MAIL_PROVIDER=postgrid` (legacy).
+
+Lob:
+
+| Variable              | Required | Notes                                |
+|-----------------------|----------|--------------------------------------|
+| `LOB_API_KEY`         | yes      |                                      |
+| `LOB_BASE_URL`        | yes      | `https://api.lob.com/v1`             |
+| `LOB_RETURN_*`        | yes      | Name/address/city/state/zip/country  |
+
+Postgrid (legacy):
+
+| Variable                          | Required | Notes                                                 |
+|-----------------------------------|----------|-------------------------------------------------------|
+| `POSTGRID_ADDVER_API_KEY`         | yes      | Address verification                                  |
+| `POSTGRID_ADDVER_BASE_URL`        | yes      | `https://api.postgrid.com/v1`                         |
+| `POSTGRID_PRINT_API_KEY`          | yes      | Print + mail                                          |
+| `POSTGRID_PRINT_BASE_URL`         | yes      | `https://api.postgrid.com/print-mail/v1`              |
+| `POSTGRID_RETURN_*`               | yes      | Name/address/city/state/zip/country                   |
+
+### Email
+
+`EMAIL_BACKEND` selects the implementation in `internal/services`:
+
+| Backend     | Variables                                                 |
+|-------------|------------------------------------------------------------|
+| `mock`      | none (development only)                                    |
+| `sendgrid`  | `SENDGRID_API_KEY`                                         |
+| `smtp`      | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`     |
+
+Common:
+
+| Variable                 | Required | Notes                                          |
+|--------------------------|----------|------------------------------------------------|
+| `EMAIL_ENABLED`          | yes      | `true` in production                           |
+| `EMAIL_VERIFICATION_URL` | yes      | Public URL for email-verify links              |
+| `EMAIL_FROM_ADDRESS`     | yes      | Must match a verified sender at the provider   |
+| `EMAIL_FROM_NAME`        | optional |                                                |
+
+Reminder: invite links, postcard codes, and addresses **must never** appear in
+email content (see [SECURITY.md](../SECURITY.md)).
+
+### Rate Limiting and CORS
+
+| Variable                  | Required | Recommended production value                            |
+|---------------------------|----------|----------------------------------------------------------|
+| `RATE_LIMIT_ENABLED`      | yes      | `true`                                                   |
+| `RATE_LIMIT_IP_LIMIT`     | yes      | `100`                                                    |
+| `RATE_LIMIT_IP_WINDOW_SECS` | yes    | `60`                                                     |
+| `CORS_ALLOWED_ORIGINS`    | yes      | Comma-separated list of public origins                   |
+
+### Observability
+
+| Variable        | Required | Notes                                       |
+|-----------------|----------|---------------------------------------------|
+| `SENTRY_DSN`    | optional | Enables Sentry error reporting if set       |
+| `LOG_LEVEL`     | optional | `info` (default), `debug`, `warn`, `error`  |
+
+## Encryption at Rest
+
+Address data never reaches the database, but **everything else** — users,
+verification metadata, audit logs, MFA secrets (already encrypted with
+AES-256-GCM at the application layer), Signal/Meshtastic group metadata — does.
+Production deployments **must** enable encryption at rest. Two supported
+approaches:
+
+1. **MariaDB data-at-rest encryption** (preferred): enable
+   `innodb_encrypt_tables=ON`, `innodb_encrypt_log=ON`, and configure a key file
+   or KMIP key management plugin. See the MariaDB
+   [Data-at-Rest Encryption docs](https://mariadb.com/kb/en/data-at-rest-encryption-overview/).
+2. **Filesystem-level encryption** on the host (e.g., LUKS) when MariaDB
+   encryption is not available.
+
+Back up keys out of band — losing them is equivalent to losing the database.
+
+## TLS
+
+Terminate TLS at Nginx or upstream load balancer. Ensure:
+
+- `SECURE_COOKIES=true` so cookies are flagged `Secure`.
+- HSTS is set on the proxy (`Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`).
+- HTTP is redirected to HTTPS at the proxy.
+
+The in-repo [`nginx.conf`](../nginx.conf) is suitable for non-TLS test
+environments; extend it for production.
+
+## Docker Compose
+
+The [`docker-compose.yml`](../docker-compose.yml) at the root is **for development**
+(hot reload, mock email, lax rate limits). For a production deployment, either:
+
+- Use the production stage of the [`Dockerfile`](../Dockerfile) directly behind
+  your orchestrator (Kubernetes, Nomad, ECS, etc.), or
+- Maintain a separate compose overlay that sets `target: production`, disables
+  the `app`/`web` dev services, and reads secrets from an external secret store.
+
+## Running Migrations on Deploy
+
+Run migrations **before** new code starts serving traffic — this keeps the schema
+ahead of the application binary so older replicas can continue serving requests
+during a rolling deploy. Migrations are idempotent (`schema_migrations` table
+tracks state) so re-running is safe.
+
+```bash
+just db-migrate
+```
+
+To roll back a single migration (only in emergencies, and only if the `.down.sql`
+is known-safe for production data):
+
+```bash
+just db-migrate-down prod 1
+```
+
+## Bootstrapping the First Superuser
+
+A superuser cannot be created via the API. Create one directly in the database
+after the first migration runs:
+
+```bash
+just create-superuser            # interactive, runs against the configured DB
+# or:
+just promote-superuser admin@example.com
+```
+
+A superuser can then grant vouch verification to other users to bootstrap
+admins per region.
+
+## Health Checks and Readiness
+
+The backend exposes:
+
+- `GET /health`        — liveness
+- `GET /api/v1/health` — same payload, aliased path for API clients
+
+Both return `{"status":"ok"}` with HTTP 200. Configure your orchestrator's
+liveness and readiness probes against one of these.
+
+## Observability and Alerting
+
+- **Errors**: forwarded to Sentry when `SENTRY_DSN` is set. Recommend tagging
+  events with `ENVIRONMENT` and `release` for triage.
+- **Audit log**: query `audit_log` for administrative actions (90-day retention
+  by design).
+- **Logs**: structured JSON via `internal/logging`. Ship to your aggregator
+  (e.g., Loki, Datadog) with request ID for tracing.
+
+## Backups and Disaster Recovery
+
+- Schedule encrypted full DB dumps daily and incremental binlog backups.
+- Test restores periodically. Keep at least one off-host copy.
+- Never include `.env` or `MFA_ENCRYPTION_KEY` material in DB backups — secrets
+  belong in a dedicated secret store (HashiCorp Vault, AWS Secrets Manager,
+  GCP Secret Manager, etc.).
+
+## Pre-Deploy Checklist
+
+- [ ] `MFA_REQUIRED=true`
+- [ ] `SECURE_COOKIES=true`
+- [ ] `RATE_LIMIT_ENABLED=true`
+- [ ] `EMAIL_ENABLED=true` with a non-mock backend
+- [ ] `JWT_SECRET` is at least 32 chars and unique per environment
+- [ ] `MFA_ENCRYPTION_KEY` is exactly 32 bytes and unique per environment
+- [ ] MariaDB data-at-rest encryption enabled (or filesystem-level equivalent)
+- [ ] TLS terminating proxy + HSTS in place
+- [ ] Sentry DSN configured
+- [ ] Migrations applied
+- [ ] Off-host encrypted backup verified by a test restore
+
+## Further Reading
+
+- [docs/ARCHITECTURE.md](ARCHITECTURE.md) — system architecture
+- [docs/API.md](API.md) — REST API reference
+- [SECURITY.md](../SECURITY.md) — disclosure policy and security posture
+- [DESIGN.md](../DESIGN.md) — full design specification


### PR DESCRIPTION
## Summary

Backfills missing top-level and supplementary documentation that was identified as a gap during a docs audit. The repo already has a strong `README.md`, exhaustive `DESIGN.md`, and a concise `CLAUDE.md`, but lacks contributor onboarding, a security disclosure policy, and structured operator/developer guides.

This PR adds:

- `CONTRIBUTING.md` — prerequisites, local setup, migrations, testing, code style, branching, and PR workflow.
- `SECURITY.md` — responsible disclosure process, scope/out-of-scope, response targets, and a summary of the security posture (zero address storage, MFA, JWT token types, rate limits, encryption at rest, audit logging).
- `docs/ARCHITECTURE.md` — pointer-style overview of the stack, package layout, request lifecycle, domain concepts (verification, geographic hierarchy, three-way XOR), and verification data flow.
- `docs/API.md` — REST endpoint reference derived from `internal/handlers/router.go`, with the JWT token-type model and rate-limit notes.
- `docs/DEPLOYMENT.md` — env var matrix, encryption-at-rest guidance, migrations on deploy, observability, and a pre-deploy checklist.
- `README.md` — new `Documentation` section cross-linking the above.

Design choice: new docs deliberately reference `DESIGN.md` as the source of truth rather than duplicating content, so the new files act as concise entry points rather than competing canonical specs.

## Test plan

- [ ] Skim each new file in the GitHub UI to verify rendering and internal links.
- [ ] Confirm the new `Documentation` section in `README.md` links to all five new docs.
- [ ] Confirm endpoint coverage in `docs/API.md` matches `internal/handlers/router.go` (no code changes; no behavioral risk).

Nightshift-Task: docs-backfill
Nightshift-Ref: https://github.com/marcus/nightshift