### PR TITLE
test: audit coverage and close two services-package gaps

### DIFF
--- a/docs/TEST_COVERAGE_GAPS.md
+++ b/docs/TEST_COVERAGE_GAPS.md
@@ -1,0 +1,128 @@
+# Test Coverage Gaps
+
+A snapshot of where the Go test suite has the thinnest coverage, intended as a
+prioritized backlog for future test work. Numbers come from `go test ./... -cover`
+and a sweep for `internal/` source files lacking a sibling `*_test.go`.
+
+This document is a survey, not a verdict on code quality — many of the lowest
+percentages reflect packages that are inherently integration-test heavy (real
+MariaDB, real HTTP handlers wired against a real router) rather than units
+worth mocking up.
+
+## Per-package coverage
+
+Captured against `main` at the time of this audit
+(commit ancestor: 8bdab47, date: 2026-06-08).
+
+| Package | Coverage | Notes |
+|---|---:|---|
+| `internal/logging` | 100.0% | Small, pure-Go logging helpers. |
+| `internal/config` | 92.1% | Env-var loading; well-covered by table tests. |
+| `internal/middleware` | 85.8% | Auth/rate-limit middleware; mostly unit-tested. |
+| `internal/services` | 48.1% → **55.4% after this PR** | Mixed: many small services covered, NCES and email mock previously 0%. |
+| `internal/sentry` | 42.6% | Optional Sentry wrapper; covers init + a subset of helpers. |
+| `cmd/doc-drift` | 54.3% | Tool-package — `main` paths uncovered. |
+| `internal/handlers` | 12.5% | HTTP handlers; most exercise the live DB via integration tests. |
+| `internal/database` | 0.2% | All meaningful coverage lives in `tests/` integration suite, not in-package unit tests. |
+| `internal/models` | no statements | Pure struct definitions. |
+| `internal/mocks` | 0.0% | Test doubles — not exercised directly. |
+| `internal/testutil` | 0.0% | Test helpers — not exercised directly. |
+| `cmd/server` | 0.0% | Process entrypoint; no tests. |
+| `cmd/seed-schools` | 0.0% | One-shot tool; no tests. |
+| `cmd/tech-debt-classify` | 0.0% | One-shot tool; no tests. |
+
+After the unit tests added in this PR:
+
+| Package | Before | After |
+|---|---:|---:|
+| `internal/services` | 48.1% | **55.4%** |
+
+(`go test ./internal/services/... -cover` on this branch.)
+
+## Source files with no sibling `*_test.go`
+
+Production code in `internal/` (and `cmd/`) that has no co-located test file. A
+missing test file does not always mean "untested" — interfaces and pure model
+types have nothing to test, and database-backed files are typically exercised
+by `tests/` integration suites rather than a unit test in the same directory.
+
+### Worth targeting (executable, unit-testable)
+
+- `internal/services/nces.go` (314 lines) — HTTP client against the NCES
+  ArcGIS API. **Addressed in this PR** via `nces_test.go` (httptest fakes).
+- `internal/services/email_mock.go` (51 lines) — `MockEmailService` used by
+  development/test paths. **Addressed in this PR** via `email_mock_test.go`.
+- `internal/services/email_sendgrid.go` (152 lines) — SendGrid REST client.
+  Worth a fake-HTTP unit test similar to `nces_test.go`. **Follow-up.**
+- `internal/handlers/router.go` (1285 lines) — route wiring. Coverage would
+  come from black-box request tests in the `tests/` suite rather than a pure
+  unit test of `router.go` itself. **Follow-up.**
+- `cmd/server/main.go` (386 lines) — bootstrapping logic. Splitting wiring
+  from `main()` would make it testable. **Follow-up.**
+
+### Tested via integration suites in `tests/`
+
+These files have no unit-test sibling, but `tests/` exercises them end-to-end
+against a real MariaDB. They are flagged here only so the gap is visible:
+
+- `internal/database/regions.go` (2158 lines)
+- `internal/database/users.go` (1010 lines)
+- `internal/database/schools.go` (841 lines — sibling `schools_test.go` does
+  exist; called out for completeness only)
+- `internal/database/verification.go` (578 lines)
+- `internal/database/signal_groups.go` (502 lines)
+- `internal/database/meshtastic_channels.go` (448 lines)
+- `internal/database/secret_update_proposals.go` (420 lines)
+- `internal/database/user_reports.go` (418 lines)
+- `internal/database/encrypted_secrets.go` (294 lines)
+- `internal/database/school_districts.go` (268 lines)
+- `internal/database/school_vouches.go` (212 lines)
+- `internal/database/encryption_keys.go` (202 lines)
+- `internal/database/errors.go` (22 lines — error sentinels only)
+
+### Nothing to test directly (interfaces / model types / test helpers)
+
+Listed for completeness; no action expected:
+
+- `internal/services/notification_queue.go` — interface only (33 lines, no
+  executable code). The interface contract is exercised by callers of
+  `NotificationService` in `notification_test.go`, and the production
+  implementation lives in `internal/database/notification_queue.go` which has
+  its own `_test.go`.
+- `internal/services/interfaces.go` — service interface declarations.
+- `internal/services/testdata/osm/fixtures.go` — fixture loader for tests.
+- `internal/mocks/services.go` — hand-written mock services.
+- `internal/testutil/testutil.go` — shared test setup helpers.
+- All `internal/models/*.go` — pure struct definitions (`no statements`
+  coverage).
+
+## Recommended priorities
+
+Ranked by **effort vs. risk reduction**, smallest/highest-impact first:
+
+1. **`internal/services/email_sendgrid.go`** — copy the `httptest`-based
+   pattern established in `nces_test.go` to cover send/error paths.
+   *(Estimated: < 1 day. Pure unit test, no external deps.)*
+2. **`internal/handlers/*` (12.5% → higher)** — add `httptest.Server`-style
+   handler tests for the highest-risk endpoints first:
+   - `/api/v1/auth/login` and MFA paths (security-critical).
+   - `/api/v1/verification/*` (security-critical, addresses).
+   - `/api/v1/blocklist-proposals/*` (consensus governance).
+   *(Estimated: 2–4 days. Requires a test DB or careful mocking of the
+   database layer.)*
+3. **`internal/database/*` (0.2% in-package)** — accept that meaningful
+   coverage will come from the `tests/` integration suite rather than
+   in-package unit tests. Track that suite's coverage separately and ensure
+   new database files always get a corresponding integration test added in
+   `tests/`.
+4. **`cmd/server/main.go`** — extract a `run(ctx, cfg) error` function so the
+   process entrypoint can be tested without spawning the binary.
+
+## Methodology
+
+- Per-package percentages: `go test ./... -cover` from a clean tree.
+- Untested file list: `find internal cmd -name '*.go' -not -name '*_test.go'`
+  cross-referenced with the presence of `<basename>_test.go` in the same
+  directory.
+- "Addressed in this PR" entries reflect tests added on branch
+  `nightshift/test-gap-finder`.

--- a/internal/services/email_mock_test.go
+++ b/internal/services/email_mock_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opencrr/communityrapidresponse.net/internal/config"
+)
+
+func newMockEmailServiceForTest(enabled bool) *MockEmailService {
+	return NewMockEmailService(&config.EmailConfig{
+		Backend:         config.EmailBackendMock,
+		Enabled:         enabled,
+		VerificationURL: "https://example.test/verify",
+		FromAddress:     "noreply@example.test",
+		FromName:        "Community Rapid Response",
+	})
+}
+
+func TestMockEmailService_BackendName(t *testing.T) {
+	svc := newMockEmailServiceForTest(true)
+	if got := svc.Backend(); got != "mock" {
+		t.Errorf("Backend() = %q, want %q", got, "mock")
+	}
+}
+
+func TestMockEmailService_IsEnabledReflectsConfig(t *testing.T) {
+	if !newMockEmailServiceForTest(true).IsEnabled() {
+		t.Error("IsEnabled() = false for enabled=true config")
+	}
+	if newMockEmailServiceForTest(false).IsEnabled() {
+		t.Error("IsEnabled() = true for enabled=false config")
+	}
+}
+
+func TestMockEmailService_SendNeverErrors(t *testing.T) {
+	svc := newMockEmailServiceForTest(true)
+	msg := &EmailMessage{
+		To:          "user@example.test",
+		Subject:     "hi",
+		TextContent: "body",
+	}
+	if err := svc.Send(context.Background(), msg); err != nil {
+		t.Errorf("Send returned error: %v", err)
+	}
+}
+
+func TestMockEmailService_SendVerificationEmailNeverErrors(t *testing.T) {
+	svc := newMockEmailServiceForTest(true)
+	if err := svc.SendVerificationEmail(context.Background(), "user@example.test", "tok"); err != nil {
+		t.Errorf("SendVerificationEmail returned error: %v", err)
+	}
+}
+
+func TestMockEmailService_SendStillSucceedsWhenDisabled(t *testing.T) {
+	// MockEmailService.Send is a no-op log line and does not gate on IsEnabled.
+	// This test pins that behavior so a future change that adds gating doesn't
+	// silently break the development setup that relies on the mock.
+	svc := newMockEmailServiceForTest(false)
+	if err := svc.Send(context.Background(), &EmailMessage{To: "x@y", Subject: "s"}); err != nil {
+		t.Errorf("Send returned error when disabled: %v", err)
+	}
+}
+

--- a/internal/services/nces.go
+++ b/internal/services/nces.go
@@ -69,8 +69,10 @@ type NCESServiceInterface interface {
 
 // NCESService handles NCES ArcGIS API interactions
 type NCESService struct {
-	client  *http.Client
-	baseURL string
+	client              *http.Client
+	baseURL             string
+	districtBaseURL     string
+	districtBoundaryURL string
 }
 
 // Compile-time assertion that NCESService implements NCESServiceInterface
@@ -82,7 +84,9 @@ func NewNCESService() *NCESService {
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		baseURL: ncesDefaultBaseURL,
+		baseURL:             ncesDefaultBaseURL,
+		districtBaseURL:     ncesDistrictBaseURL,
+		districtBoundaryURL: ncesDistrictBoundaryBaseURL,
 	}
 }
 
@@ -157,12 +161,12 @@ func (s *NCESService) fetchSchools(ctx context.Context, whereClause string, offs
 
 // fetchDistricts is the internal method for district queries.
 func (s *NCESService) fetchDistricts(ctx context.Context, whereClause string, offset, limit int) ([]NCESDistrict, int, error) {
-	totalCount, err := s.fetchCount(ctx, ncesDistrictBaseURL, whereClause)
+	totalCount, err := s.fetchCount(ctx, s.districtBaseURL, whereClause)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to fetch district count: %w", err)
 	}
 
-	records, err := s.fetchPage(ctx, ncesDistrictBaseURL, whereClause, ncesDistrictOutFields, offset, limit)
+	records, err := s.fetchPage(ctx, s.districtBaseURL, whereClause, ncesDistrictOutFields, offset, limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to fetch districts: %w", err)
 	}
@@ -227,7 +231,7 @@ func (s *NCESService) FetchDistrictBoundary(ctx context.Context, geoid string) (
 	params.Set("outSR", "4326")
 	params.Set("f", "geojson")
 
-	requestURL := ncesDistrictBoundaryBaseURL + "?" + params.Encode()
+	requestURL := s.districtBoundaryURL + "?" + params.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
 	if err != nil {

--- a/internal/services/nces_test.go
+++ b/internal/services/nces_test.go
@@ -1,0 +1,378 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestNCESService returns an NCESService whose three ArcGIS endpoints are
+// pointed at the given httptest server. The server's handler is responsible
+// for routing on path or query params.
+func newTestNCESService(server *httptest.Server) *NCESService {
+	return &NCESService{
+		client:              server.Client(),
+		baseURL:             server.URL + "/schools",
+		districtBaseURL:     server.URL + "/districts",
+		districtBoundaryURL: server.URL + "/boundaries",
+	}
+}
+
+// ncesFakeResponse describes a single canned response keyed by the request's
+// `returnCountOnly` flag, so a fake server can answer both the count query
+// and the page query that every fetch issues.
+type ncesFakeResponse struct {
+	count int
+	page  string
+}
+
+// arcGISHandler returns a handler that serves a count payload when
+// returnCountOnly=true and the supplied features payload otherwise.
+func arcGISHandler(t *testing.T, resp ncesFakeResponse) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("returnCountOnly") == "true" {
+			_, _ = w.Write([]byte(`{"count":` + itoa(resp.count) + `}`))
+			return
+		}
+		_, _ = w.Write([]byte(resp.page))
+	}
+}
+
+// itoa avoids pulling in strconv just for one digit-string conversion in the
+// fake response helper above.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func TestNCESService_FetchSchools(t *testing.T) {
+	page := `{"features":[
+		{"attributes":{"NCESSCH":"001","NAME":"Alpha High","LEAID":"L1","STREET":"1 A St","CITY":"Town","STATE":"CA","ZIP":"94000","LAT":37.5,"LON":-122.5}},
+		{"attributes":{"NCESSCH":"002","NAME":"Beta High","LEAID":"L1","STREET":"2 B St","CITY":"Town","STATE":"CA","ZIP":"94000","LAT":37.6,"LON":-122.6}}
+	]}`
+
+	var lastQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastQuery = r.URL.Query()
+		arcGISHandler(t, ncesFakeResponse{count: 42, page: page})(w, r)
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	schools, total, err := svc.FetchSchools(context.Background(), 100, 50)
+	if err != nil {
+		t.Fatalf("FetchSchools: unexpected error: %v", err)
+	}
+	if total != 42 {
+		t.Errorf("total = %d, want 42", total)
+	}
+	if len(schools) != 2 {
+		t.Fatalf("got %d schools, want 2", len(schools))
+	}
+	if schools[0].NCESSCH != "001" || schools[0].Name != "Alpha High" {
+		t.Errorf("school[0] = %+v, want NCESSCH=001 Name=Alpha High", schools[0])
+	}
+	if schools[1].Lat != 37.6 {
+		t.Errorf("school[1].Lat = %v, want 37.6", schools[1].Lat)
+	}
+
+	// The final (page) request must carry pagination + outFields + a base where clause.
+	if got := lastQuery.Get("resultOffset"); got != "100" {
+		t.Errorf("resultOffset = %q, want 100", got)
+	}
+	if got := lastQuery.Get("resultRecordCount"); got != "50" {
+		t.Errorf("resultRecordCount = %q, want 50", got)
+	}
+	if got := lastQuery.Get("outFields"); got != ncesSchoolOutFields {
+		t.Errorf("outFields = %q, want %q", got, ncesSchoolOutFields)
+	}
+	if got := lastQuery.Get("where"); got != "1=1" {
+		t.Errorf("where = %q, want 1=1", got)
+	}
+}
+
+func TestNCESService_FetchSchoolsByState_WhereClause(t *testing.T) {
+	page := `{"features":[{"attributes":{"NCESSCH":"010","NAME":"Gamma","LEAID":"L2","STREET":"","CITY":"","STATE":"CA","ZIP":"","LAT":0,"LON":0}}]}`
+
+	var pageWhere string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("returnCountOnly") != "true" {
+			pageWhere = r.URL.Query().Get("where")
+		}
+		arcGISHandler(t, ncesFakeResponse{count: 1, page: page})(w, r)
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	schools, total, err := svc.FetchSchoolsByState(context.Background(), "CA", 0, 10)
+	if err != nil {
+		t.Fatalf("FetchSchoolsByState: unexpected error: %v", err)
+	}
+	if total != 1 || len(schools) != 1 {
+		t.Fatalf("got total=%d schools=%d, want 1/1", total, len(schools))
+	}
+	if pageWhere != "STATE='CA'" {
+		t.Errorf("page where = %q, want STATE='CA'", pageWhere)
+	}
+}
+
+func TestNCESService_FetchDistricts(t *testing.T) {
+	page := `{"features":[
+		{"attributes":{"LEAID":"L1","NAME":"Unified","STATE":"CA"}},
+		{"attributes":{"LEAID":"L2","NAME":"Elementary","STATE":"NY"}}
+	]}`
+
+	var hitDistrictsEndpoint bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/districts") {
+			hitDistrictsEndpoint = true
+		}
+		arcGISHandler(t, ncesFakeResponse{count: 2, page: page})(w, r)
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	districts, total, err := svc.FetchDistricts(context.Background(), 0, 25)
+	if err != nil {
+		t.Fatalf("FetchDistricts: unexpected error: %v", err)
+	}
+	if !hitDistrictsEndpoint {
+		t.Errorf("expected request against /districts endpoint, got none")
+	}
+	if total != 2 || len(districts) != 2 {
+		t.Fatalf("got total=%d districts=%d, want 2/2", total, len(districts))
+	}
+	if districts[0].LEAID != "L1" || districts[0].Name != "Unified" {
+		t.Errorf("districts[0] = %+v, want LEAID=L1 Name=Unified", districts[0])
+	}
+}
+
+func TestNCESService_FetchDistrictsByState(t *testing.T) {
+	page := `{"features":[{"attributes":{"LEAID":"L9","NAME":"Solo","STATE":"WA"}}]}`
+
+	var pageWhere string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("returnCountOnly") != "true" {
+			pageWhere = r.URL.Query().Get("where")
+		}
+		arcGISHandler(t, ncesFakeResponse{count: 1, page: page})(w, r)
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	districts, _, err := svc.FetchDistrictsByState(context.Background(), "WA", 0, 10)
+	if err != nil {
+		t.Fatalf("FetchDistrictsByState: unexpected error: %v", err)
+	}
+	if len(districts) != 1 || districts[0].State != "WA" {
+		t.Errorf("districts = %+v, want one WA district", districts)
+	}
+	if pageWhere != "STATE='WA'" {
+		t.Errorf("page where = %q, want STATE='WA'", pageWhere)
+	}
+}
+
+func TestNCESService_FetchDistrictBoundary(t *testing.T) {
+	geom := `{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}`
+	body := `{"features":[{"geometry":` + geom + `}]}`
+
+	var requestedWhere string
+	var requestedF string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedWhere = r.URL.Query().Get("where")
+		requestedF = r.URL.Query().Get("f")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	geo, err := svc.FetchDistrictBoundary(context.Background(), "0612345")
+	if err != nil {
+		t.Fatalf("FetchDistrictBoundary: unexpected error: %v", err)
+	}
+	if requestedWhere != "GEOID='0612345'" {
+		t.Errorf("where = %q, want GEOID='0612345'", requestedWhere)
+	}
+	if requestedF != "geojson" {
+		t.Errorf("f = %q, want geojson", requestedF)
+	}
+
+	// The returned geometry should round-trip back to the same JSON object.
+	var got, want map[string]any
+	if err := json.Unmarshal([]byte(geo), &got); err != nil {
+		t.Fatalf("returned geometry is not JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(geom), &want); err != nil {
+		t.Fatalf("expected geometry is not JSON: %v", err)
+	}
+	if !equalJSON(got, want) {
+		t.Errorf("geometry mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestNCESService_FetchDistrictBoundary_NoFeatures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"features":[]}`))
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	geo, err := svc.FetchDistrictBoundary(context.Background(), "9999999")
+	if err != nil {
+		t.Fatalf("FetchDistrictBoundary: unexpected error: %v", err)
+	}
+	if geo != "" {
+		t.Errorf("expected empty geometry for no-features response, got %q", geo)
+	}
+}
+
+func TestNCESService_FetchSchools_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`upstream broken`))
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	_, _, err := svc.FetchSchools(context.Background(), 0, 10)
+	if err == nil {
+		t.Fatal("expected error from 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "count API error") {
+		t.Errorf("error = %q, want it to mention count API error", err.Error())
+	}
+}
+
+func TestNCESService_FetchSchools_MalformedCountJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("returnCountOnly") == "true" {
+			_, _ = w.Write([]byte(`not-json`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"features":[]}`))
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	_, _, err := svc.FetchSchools(context.Background(), 0, 10)
+	if err == nil {
+		t.Fatal("expected JSON parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse count response") {
+		t.Errorf("error = %q, want it to mention parse count response", err.Error())
+	}
+}
+
+func TestNCESService_FetchSchools_MalformedPageJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("returnCountOnly") == "true" {
+			_, _ = w.Write([]byte(`{"count":1}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	_, _, err := svc.FetchSchools(context.Background(), 0, 10)
+	if err == nil {
+		t.Fatal("expected JSON parse error on page, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse response") {
+		t.Errorf("error = %q, want it to mention parse response", err.Error())
+	}
+}
+
+func TestNCESService_FetchSchools_BadRecord(t *testing.T) {
+	// Page parses successfully but the per-record JSON has a type mismatch
+	// (LAT is a string instead of a number), which should bubble up as a
+	// "failed to parse school record" error.
+	page := `{"features":[{"attributes":{"NCESSCH":"001","NAME":"Bad","LEAID":"","STREET":"","CITY":"","STATE":"","ZIP":"","LAT":"not-a-number","LON":0}}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arcGISHandler(t, ncesFakeResponse{count: 1, page: page})(w, r)
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	_, _, err := svc.FetchSchools(context.Background(), 0, 10)
+	if err == nil {
+		t.Fatal("expected per-record parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse school record") {
+		t.Errorf("error = %q, want it to mention parse school record", err.Error())
+	}
+}
+
+func TestNCESService_FetchDistrictBoundary_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`gateway down`))
+	}))
+	defer server.Close()
+
+	svc := newTestNCESService(server)
+	_, err := svc.FetchDistrictBoundary(context.Background(), "0612345")
+	if err == nil {
+		t.Fatal("expected error from 502 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "boundary API error") {
+		t.Errorf("error = %q, want it to mention boundary API error", err.Error())
+	}
+}
+
+func TestNewNCESService_DefaultsToProductionURLs(t *testing.T) {
+	svc := NewNCESService()
+	if svc.baseURL != ncesDefaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", svc.baseURL, ncesDefaultBaseURL)
+	}
+	if svc.districtBaseURL != ncesDistrictBaseURL {
+		t.Errorf("districtBaseURL = %q, want %q", svc.districtBaseURL, ncesDistrictBaseURL)
+	}
+	if svc.districtBoundaryURL != ncesDistrictBoundaryBaseURL {
+		t.Errorf("districtBoundaryURL = %q, want %q", svc.districtBoundaryURL, ncesDistrictBoundaryBaseURL)
+	}
+	if svc.client == nil || svc.client.Timeout == 0 {
+		t.Errorf("expected an HTTP client with a non-zero timeout, got %+v", svc.client)
+	}
+}
+
+// equalJSON does a shallow structural comparison sufficient for the small
+// polygon fixtures used here.
+func equalJSON(a, b map[string]any) bool {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}


### PR DESCRIPTION
## Summary

- Adds `docs/TEST_COVERAGE_GAPS.md` recording current per-package coverage (database 0.2%, handlers 12.5%, services 48.1%, sentry 42.6%, cmd/server 0%) and listing internal/ source files with no sibling test.
- Adds `internal/services/nces_test.go` — `httptest.Server` fakes for the NCES ArcGIS endpoints, covering `FetchSchools`, `FetchSchoolsByState`, `FetchDistricts`, `FetchDistrictsByState`, and `FetchDistrictBoundary`, plus URL/query construction and JSON/HTTP error paths. Required a small refactor in `nces.go` to make the district and boundary URLs struct fields (still defaulted to the existing production constants in `NewNCESService`) instead of hard-coded references.
- Adds `internal/services/email_mock_test.go` — covers `MockEmailService` methods (`Backend`, `IsEnabled`, `Send`, `SendVerificationEmail`), which were previously 0% covered.

`internal/services` package coverage rises from **48.1% → 55.4%**.

## Plan deviation

The plan called for `internal/services/notification_queue_test.go` as the second target, but that file is purely an interface declaration (no executable code) — the interface contract is already exercised by `notification_test.go` and the production implementation lives in `internal/database/notification_queue.go` with its own test. I substituted `email_mock.go` (also a "small surface, currently 0% covered" file in the same package). The substitution and reasoning are documented in `docs/TEST_COVERAGE_GAPS.md`.

The larger gaps in `internal/database` and `internal/handlers` are integration-test heavy (require MariaDB) and are flagged in the report as follow-up work rather than tackled in this PR, keeping the change reviewable.

## Test plan

- [x] `go test ./internal/services/... -run 'NCES|MockEmail' -v` — all new tests pass
- [x] `go test ./... -cover` — services coverage rose from 48.1% to 55.4%; no other package regressed
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues